### PR TITLE
Jordan Wigner transformation from fermions to spins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ documentation/_build*
 documentation/generated*
 .vscode
 */__pycache__/*
+*.~undo-tree~

--- a/struqture/src/bosons/bosonic_noise_operator.rs
+++ b/struqture/src/bosons/bosonic_noise_operator.rs
@@ -150,7 +150,8 @@ impl<'a> OperateOnDensityMatrix<'a> for BosonLindbladNoiseOperator {
     ///
     /// * `Ok(Some(CalculatorComplex))` - The key existed, this is the value it had before it was set with the value input.
     /// * `Ok(None)` - The key did not exist, it has been set with its corresponding value.
-    /// * `Err(StruqtureError)` - The input contained identities, which are not allowed as Lindblad operators.
+    /// * `Err(StruqtureError::InvalidLindbladTerms)` - The input contained identities, which are not allowed as Lindblad operators.
+    ///
     /// # Panics
     ///
     /// * Internal error in BosonProduct::new
@@ -160,10 +161,9 @@ impl<'a> OperateOnDensityMatrix<'a> for BosonLindbladNoiseOperator {
         value: Self::Value,
     ) -> Result<Option<Self::Value>, StruqtureError> {
         if key.0
-            == BosonProduct::new([], []).expect("Internal error when creating empty BosonProduct.")
+            == BosonProduct::new([], [])?
             || key.1
-                == BosonProduct::new([], [])
-                    .expect("Internal error when creating empty BosonProduct.")
+                == BosonProduct::new([], [])?
         {
             return Err(StruqtureError::InvalidLindbladTerms);
         }

--- a/struqture/src/bosons/bosonic_noise_operator.rs
+++ b/struqture/src/bosons/bosonic_noise_operator.rs
@@ -160,11 +160,7 @@ impl<'a> OperateOnDensityMatrix<'a> for BosonLindbladNoiseOperator {
         key: Self::Index,
         value: Self::Value,
     ) -> Result<Option<Self::Value>, StruqtureError> {
-        if key.0
-            == BosonProduct::new([], [])?
-            || key.1
-                == BosonProduct::new([], [])?
-        {
+        if key.0 == BosonProduct::new([], [])? || key.1 == BosonProduct::new([], [])? {
             return Err(StruqtureError::InvalidLindbladTerms);
         }
 

--- a/struqture/src/bosons/bosonic_noise_operator.rs
+++ b/struqture/src/bosons/bosonic_noise_operator.rs
@@ -151,13 +151,19 @@ impl<'a> OperateOnDensityMatrix<'a> for BosonLindbladNoiseOperator {
     /// * `Ok(Some(CalculatorComplex))` - The key existed, this is the value it had before it was set with the value input.
     /// * `Ok(None)` - The key did not exist, it has been set with its corresponding value.
     /// * `Err(StruqtureError)` - The input contained identities, which are not allowed as Lindblad operators.
+    /// # Panics
+    ///
+    /// * Internal error in BosonProduct::new
     fn set(
         &mut self,
         key: Self::Index,
         value: Self::Value,
     ) -> Result<Option<Self::Value>, StruqtureError> {
-        if key.0 == BosonProduct::new([], []).unwrap()
-            || key.1 == BosonProduct::new([], []).unwrap()
+        if key.0
+            == BosonProduct::new([], []).expect("Internal error when creating empty BosonProduct.")
+            || key.1
+                == BosonProduct::new([], [])
+                    .expect("Internal error when creating empty BosonProduct.")
         {
             return Err(StruqtureError::InvalidLindbladTerms);
         }
@@ -170,32 +176,6 @@ impl<'a> OperateOnDensityMatrix<'a> for BosonLindbladNoiseOperator {
                 Entry::Vacant(_) => Ok(None),
             }
         }
-    }
-
-    /// Adds a new entry in the BosonLindbladNoiseOperator with the given ((BosonProduct, BosonProduct) key, CalculatorComplex value) pair.
-    ///
-    /// # Arguments
-    ///
-    /// * `key` - The (BosonProduct, BosonProduct) key to set in the BosonLindbladNoiseOperator.
-    /// * `value` - The corresponding CalculatorComplex value to set for the key in the BosonLindbladNoiseOperator.
-    ///
-    /// # Returns
-    ///
-    /// * `Err(StruqtureError)` - The input contained identities, which are not allowed as Lindblad operators.
-    fn add_operator_product(
-        &mut self,
-        key: Self::Index,
-        value: Self::Value,
-    ) -> Result<(), StruqtureError> {
-        if key.0 == BosonProduct::new([], []).unwrap()
-            || key.1 == BosonProduct::new([], []).unwrap()
-        {
-            return Err(StruqtureError::InvalidLindbladTerms);
-        }
-
-        let old = self.get(&key).clone();
-        self.set(key, value + old)?;
-        Ok(())
     }
 }
 

--- a/struqture/src/fermions/fermionic_hamiltonian.rs
+++ b/struqture/src/fermions/fermionic_hamiltonian.rs
@@ -13,6 +13,8 @@
 use super::{
     FermionOperator, FermionProduct, HermitianFermionProduct, ModeIndex, OperateOnFermions,
 };
+use crate::mappings::JordanWignerFermionToSpin;
+use crate::spins::SpinHamiltonian;
 use crate::{
     GetValue, OperateOnDensityMatrix, OperateOnModes, OperateOnState, StruqtureError,
     StruqtureVersionSerializable, SymmetricIndex,
@@ -567,6 +569,28 @@ impl fmt::Display for FermionHamiltonian {
         output.push('}');
 
         write!(f, "{}", output)
+    }
+}
+
+impl JordanWignerFermionToSpin for FermionHamiltonian {
+    type Output = SpinHamiltonian;
+
+    /// Implements JordanWignerFermionToSpin for a FermionHamiltonian.
+    ///
+    /// The convention used is that |0> represents an empty fermionic state (spin-orbital),
+    /// and |1> represents an occupied fermionic state.
+    ///
+    /// # Returns
+    ///
+    /// `SpinHamiltonian` - The spin Hamiltonian that results from the transformation.
+    fn jordan_wigner(&self) -> Self::Output {
+        let mut out = SpinHamiltonian::new();
+        for hfp in self.keys() {
+            let mut new_term = hfp.jordan_wigner();
+            new_term = new_term*(self.get(hfp));
+            out = out + SpinHamiltonian::try_from(new_term).unwrap();
+        }
+        out
     }
 }
 

--- a/struqture/src/fermions/fermionic_hamiltonian.rs
+++ b/struqture/src/fermions/fermionic_hamiltonian.rs
@@ -587,7 +587,7 @@ impl JordanWignerFermionToSpin for FermionHamiltonian {
         let mut out = SpinHamiltonian::new();
         for hfp in self.keys() {
             let mut new_term = hfp.jordan_wigner();
-            let mut new_coeff = CalculatorFloat::from(self.get(hfp).re.clone());
+            let mut new_coeff = self.get(hfp).re.clone();
             if hfp.is_natural_hermitian() {
                 new_coeff *= 2.0;
             }

--- a/struqture/src/fermions/fermionic_hamiltonian.rs
+++ b/struqture/src/fermions/fermionic_hamiltonian.rs
@@ -29,7 +29,7 @@ use std::ops;
 
 /// FermionHamiltonians are combinations of FermionProducts with specific CalculatorComplex coefficients.
 ///
-/// This is a representation of sums of pauli products with weightings, in order to build a full hamiltonian.
+/// This is a representation of sums of creation and annihilation operators with weightings, in order to build a full hamiltonian.
 /// FermionHamiltonian is the hermitian equivalent of FermionOperator.
 ///
 /// # Example
@@ -587,8 +587,12 @@ impl JordanWignerFermionToSpin for FermionHamiltonian {
         let mut out = SpinHamiltonian::new();
         for hfp in self.keys() {
             let mut new_term = hfp.jordan_wigner();
-            new_term = new_term * (self.get(hfp));
-            out = out + SpinHamiltonian::try_from(new_term).unwrap();
+            let mut new_coeff = CalculatorFloat::from(self.get(hfp).re.clone());
+            if hfp.is_natural_hermitian() {
+                new_coeff *= 2.0;
+            }
+            new_term = new_term * new_coeff;
+            out = out + new_term;
         }
         out
     }

--- a/struqture/src/fermions/fermionic_hamiltonian.rs
+++ b/struqture/src/fermions/fermionic_hamiltonian.rs
@@ -587,7 +587,7 @@ impl JordanWignerFermionToSpin for FermionHamiltonian {
         let mut out = SpinHamiltonian::new();
         for hfp in self.keys() {
             let mut new_term = hfp.jordan_wigner();
-            new_term = new_term*(self.get(hfp));
+            new_term = new_term * (self.get(hfp));
             out = out + SpinHamiltonian::try_from(new_term).unwrap();
         }
         out

--- a/struqture/src/fermions/fermionic_hamiltonian_system.rs
+++ b/struqture/src/fermions/fermionic_hamiltonian_system.rs
@@ -13,6 +13,8 @@
 use super::{
     FermionHamiltonian, FermionSystem, HermitianFermionProduct, ModeIndex, OperateOnFermions,
 };
+use crate::mappings::JordanWignerFermionToSpin;
+use crate::spins::{SpinHamiltonian, SpinHamiltonianSystem};
 use crate::{OperateOnDensityMatrix, OperateOnModes, OperateOnState, StruqtureError};
 use qoqo_calculator::{CalculatorComplex, CalculatorFloat};
 use serde::{Deserialize, Serialize};
@@ -497,5 +499,25 @@ impl fmt::Display for FermionHamiltonianSystem {
         output.push('}');
 
         write!(f, "{}", output)
+    }
+}
+
+impl JordanWignerFermionToSpin for FermionHamiltonianSystem {
+    type Output = SpinHamiltonianSystem;
+
+    /// Implements JordanWignerFermionToSpin for a FermionHamiltonianSystem.
+    ///
+    /// The convention used is that |0> represents an empty fermionic state (spin-orbital),
+    /// and |1> represents an occupied fermionic state.
+    ///
+    /// # Returns
+    ///
+    /// `SpinHamiltonianSystem` - The spin noise operator that results from the transformation.
+    fn jordan_wigner(&self) -> Self::Output {
+        SpinHamiltonianSystem::from_hamiltonian(
+            self.hamiltonian().jordan_wigner(),
+            Some(self.number_modes()),
+        )
+        .unwrap()
     }
 }

--- a/struqture/src/fermions/fermionic_hamiltonian_system.rs
+++ b/struqture/src/fermions/fermionic_hamiltonian_system.rs
@@ -14,7 +14,7 @@ use super::{
     FermionHamiltonian, FermionSystem, HermitianFermionProduct, ModeIndex, OperateOnFermions,
 };
 use crate::mappings::JordanWignerFermionToSpin;
-use crate::spins::{SpinHamiltonian, SpinHamiltonianSystem};
+use crate::spins::SpinHamiltonianSystem;
 use crate::{OperateOnDensityMatrix, OperateOnModes, OperateOnState, StruqtureError};
 use qoqo_calculator::{CalculatorComplex, CalculatorFloat};
 use serde::{Deserialize, Serialize};

--- a/struqture/src/fermions/fermionic_hamiltonian_system.rs
+++ b/struqture/src/fermions/fermionic_hamiltonian_system.rs
@@ -538,11 +538,14 @@ impl JordanWignerFermionToSpin for FermionHamiltonianSystem {
     /// # Returns
     ///
     /// `SpinHamiltonianSystem` - The spin noise operator that results from the transformation.
+    /// # Panics
+    ///
+    /// * Internal error in jordan_wigner transformation for FermionHamiltonian.
     fn jordan_wigner(&self) -> Self::Output {
         SpinHamiltonianSystem::from_hamiltonian(
             self.hamiltonian().jordan_wigner(),
             Some(self.number_modes()),
         )
-        .unwrap()
+        .expect("Internal bug in jordan_wigner for FermionHamiltonian. The number of spins in the resulting Hamiltonian should equal the number of modes of the FermionHamiltonian.")
     }
 }

--- a/struqture/src/fermions/fermionic_indices.rs
+++ b/struqture/src/fermions/fermionic_indices.rs
@@ -1118,7 +1118,6 @@ impl GetValue<HermitianFermionProduct> for FermionProduct {
     ///
     /// # Arguments
     ///
-
     /// * `index` - The HermitianFermionProduct to transform the value by.
     /// * `value` - The value to be transformed.
     ///
@@ -1297,6 +1296,9 @@ impl JordanWignerFermionToSpin for HermitianFermionProduct {
     /// `SpinHamiltonian` - The spin operator that results from the transformation.
     ///
     /// * Unexpectedly failed to add a PauliProduct to a SpinOperator or SpinHamiltonian internal struqture bug.
+    ///
+    /// # Panics
+    ///
     /// * Internal bug in `add_operator_product`.
     fn jordan_wigner(&self) -> Self::Output {
         let number_creators = self.number_creators();
@@ -1346,7 +1348,9 @@ impl JordanWignerFermionToSpin for HermitianFermionProduct {
             }
             return out;
         }
-        SpinHamiltonian::try_from(spin_operator).unwrap()
+        SpinHamiltonian::try_from(spin_operator).expect("Error in conversion from SpinOperator to
+SpinHamiltonian, despite the internal check that the HermitianFermionProduct in the jordan-wigner
+transform is hermitian.")
     }
 }
 

--- a/struqture/src/fermions/fermionic_indices.rs
+++ b/struqture/src/fermions/fermionic_indices.rs
@@ -1254,7 +1254,7 @@ impl<T: FermionIndex> JordanWignerFermionToSpin for T {
     /// # Returns
     ///
     /// `SpinOperator` - The spin operator that results from the transformation.
-    fn jordan_wigner(self) -> Self::Output {
+    fn jordan_wigner(&self) -> Self::Output {
         let number_creators = self.number_creators();
         let number_annihilators = self.number_annihilators();
         let mut spin_operator = SpinOperator::new();

--- a/struqture/src/fermions/fermionic_indices.rs
+++ b/struqture/src/fermions/fermionic_indices.rs
@@ -1240,6 +1240,11 @@ impl JordanWignerFermionToSpin for FermionProduct {
     /// # Returns
     ///
     /// `SpinOperator` - The spin operator that results from the transformation.
+    ///
+    /// # Panics
+    ///
+    /// * Unexpectedly failed to add a PauliProduct to a SpinOperator internal struqture bug.
+    /// * Internal bug in `add_operator_product`.
     fn jordan_wigner(&self) -> Self::Output {
         let number_creators = self.number_creators();
         let number_annihilators = self.number_annihilators();
@@ -1249,7 +1254,7 @@ impl JordanWignerFermionToSpin for FermionProduct {
         id = id.set_pauli(0, SingleSpinOperator::Identity);
         spin_operator
             .add_operator_product(id, CalculatorComplex::new(1.0, 0.0))
-            .unwrap();
+            .expect("Internal bug in add_operator_product.");
 
         // Jordan-Wigner strings are inserted every second lowering (raising) operator, in even or
         // odd positions depending on the parity of the total number of creation (annihilation)
@@ -1290,6 +1295,9 @@ impl JordanWignerFermionToSpin for HermitianFermionProduct {
     /// # Returns
     ///
     /// `SpinHamiltonian` - The spin operator that results from the transformation.
+    ///
+    /// * Unexpectedly failed to add a PauliProduct to a SpinOperator or SpinHamiltonian internal struqture bug.
+    /// * Internal bug in `add_operator_product`.
     fn jordan_wigner(&self) -> Self::Output {
         let number_creators = self.number_creators();
         let number_annihilators = self.number_annihilators();
@@ -1299,7 +1307,7 @@ impl JordanWignerFermionToSpin for HermitianFermionProduct {
         id = id.set_pauli(0, SingleSpinOperator::Identity);
         spin_operator
             .add_operator_product(id, CalculatorComplex::new(1.0, 0.0))
-            .unwrap();
+            .expect("Internal bug in add_operator_product.");
 
         // Jordan-Wigner strings are inserted every second lowering (raising) operator, in even or
         // odd positions depending on the parity of the total number of creation (annihilation)
@@ -1333,7 +1341,7 @@ impl JordanWignerFermionToSpin for HermitianFermionProduct {
             for (product, coeff) in spin_operator.iter() {
                 if coeff.im == 0.0.into() {
                     out.add_operator_product(product.clone(), coeff.re.clone() * 2)
-                        .unwrap();
+                        .expect("Internal bug in add_operator_product.");
                 }
             }
             return out;

--- a/struqture/src/fermions/fermionic_indices.rs
+++ b/struqture/src/fermions/fermionic_indices.rs
@@ -1346,9 +1346,11 @@ impl JordanWignerFermionToSpin for HermitianFermionProduct {
             }
             return out;
         }
-        SpinHamiltonian::try_from(spin_operator).expect("Error in conversion from SpinOperator to
+        SpinHamiltonian::try_from(spin_operator).expect(
+            "Error in conversion from SpinOperator to
 SpinHamiltonian, despite the internal check that the HermitianFermionProduct in the jordan-wigner
-transform is hermitian.")
+transform is hermitian.",
+        )
     }
 }
 

--- a/struqture/src/fermions/fermionic_indices.rs
+++ b/struqture/src/fermions/fermionic_indices.rs
@@ -11,12 +11,12 @@
 // limitations under the License.
 
 use super::FermionIndex;
+use crate::mappings::JordanWignerFermionToSpin;
+use crate::prelude::*;
+use crate::spins::{PauliProduct, SingleSpinOperator, SpinOperator};
 use crate::{
     CorrespondsTo, CreatorsAnnihilators, GetValue, ModeIndex, StruqtureError, SymmetricIndex,
 };
-use crate::spins::{PauliProduct, SingleSpinOperator, SpinOperator};
-use crate::mappings::JordanWignerFermionToSpin;
-use crate::prelude::*;
 
 use qoqo_calculator::CalculatorComplex;
 use serde::{
@@ -1231,17 +1231,20 @@ fn sort_and_signal(indices: TinyVec<[usize; 2]>) -> (TinyVec<[usize; 2]>, bool, 
 
 fn _lowering_operator(i: &usize) -> SpinOperator {
     let mut out = SpinOperator::new();
-    out.add_operator_product(PauliProduct::new().x(*i), CalculatorComplex::new(0.5, 0.0)).unwrap();
-    out.add_operator_product(PauliProduct::new().y(*i), CalculatorComplex::new(0.0, -0.5)).unwrap();
+    out.add_operator_product(PauliProduct::new().x(*i), CalculatorComplex::new(0.5, 0.0))
+        .unwrap();
+    out.add_operator_product(PauliProduct::new().y(*i), CalculatorComplex::new(0.0, -0.5))
+        .unwrap();
     out
 }
 fn _raising_operator(i: &usize) -> SpinOperator {
     let mut out = SpinOperator::new();
-    out.add_operator_product(PauliProduct::new().x(*i), CalculatorComplex::new(0.5, 0.0)).unwrap();
-    out.add_operator_product(PauliProduct::new().y(*i), CalculatorComplex::new(0.0, 0.5)).unwrap();
+    out.add_operator_product(PauliProduct::new().x(*i), CalculatorComplex::new(0.5, 0.0))
+        .unwrap();
+    out.add_operator_product(PauliProduct::new().y(*i), CalculatorComplex::new(0.0, 0.5))
+        .unwrap();
     out
 }
-
 
 impl<T: FermionIndex> JordanWignerFermionToSpin for T {
     type Output = SpinOperator;
@@ -1261,15 +1264,17 @@ impl<T: FermionIndex> JordanWignerFermionToSpin for T {
 
         let mut id = PauliProduct::new();
         id = id.set_pauli(0, SingleSpinOperator::Identity);
-        spin_operator.add_operator_product(id.clone(), CalculatorComplex::new(1.0, 0.0)).unwrap();
-        
+        spin_operator
+            .add_operator_product(id.clone(), CalculatorComplex::new(1.0, 0.0))
+            .unwrap();
+
         // Jordan-Wigner strings are inserted every second lowering (raising) operator, in even or
         // odd positions depending on the parity of the total number of creation (annihilation)
-        // operators. 
+        // operators.
         let mut previous = 0;
         for (index, site) in self.creators().enumerate() {
-            if index%2 != number_creators%2 {
-                for i in previous..*site {                    
+            if index % 2 != number_creators % 2 {
+                for i in previous..*site {
                     spin_operator = spin_operator * PauliProduct::new().z(i)
                 }
             }
@@ -1279,8 +1284,8 @@ impl<T: FermionIndex> JordanWignerFermionToSpin for T {
 
         previous = 0;
         for (index, site) in self.annihilators().enumerate() {
-            if index%2 != number_annihilators%2 {
-                for i in previous..*site {                    
+            if index % 2 != number_annihilators % 2 {
+                for i in previous..*site {
                     spin_operator = spin_operator * PauliProduct::new().z(i)
                 }
             }
@@ -1289,21 +1294,23 @@ impl<T: FermionIndex> JordanWignerFermionToSpin for T {
         }
 
         // For HermitianFermionProduct, spin terms with imaginary coefficients are dropped, and
-        // real coefficients are doubled. 
-        if !self.is_natural_hermitian() &&
-            std::any::type_name::<T>() == std::any::type_name::<HermitianFermionProduct>() {
-                let mut out = SpinOperator::new();
-                for (product, coeff) in spin_operator.iter() {
-                    if coeff.im == 0.0.into() {
-                        out.add_operator_product(product.clone(), CalculatorComplex::new(
-                            coeff.re.clone()*2, 0.0
-                        )).unwrap();
-                    }
+        // real coefficients are doubled.
+        if !self.is_natural_hermitian()
+            && std::any::type_name::<T>() == std::any::type_name::<HermitianFermionProduct>()
+        {
+            let mut out = SpinOperator::new();
+            for (product, coeff) in spin_operator.iter() {
+                if coeff.im == 0.0.into() {
+                    out.add_operator_product(
+                        product.clone(),
+                        CalculatorComplex::new(coeff.re.clone() * 2, 0.0),
+                    )
+                    .unwrap();
                 }
-                return out
             }
+            return out;
+        }
         spin_operator
-
     }
 }
 

--- a/struqture/src/fermions/fermionic_indices.rs
+++ b/struqture/src/fermions/fermionic_indices.rs
@@ -1248,7 +1248,7 @@ impl JordanWignerFermionToSpin for FermionProduct {
         let mut id = PauliProduct::new();
         id = id.set_pauli(0, SingleSpinOperator::Identity);
         spin_operator
-            .add_operator_product(id.clone(), CalculatorComplex::new(1.0, 0.0))
+            .add_operator_product(id, CalculatorComplex::new(1.0, 0.0))
             .unwrap();
 
         // Jordan-Wigner strings are inserted every second lowering (raising) operator, in even or
@@ -1298,7 +1298,7 @@ impl JordanWignerFermionToSpin for HermitianFermionProduct {
         let mut id = PauliProduct::new();
         id = id.set_pauli(0, SingleSpinOperator::Identity);
         spin_operator
-            .add_operator_product(id.clone(), CalculatorComplex::new(1.0, 0.0))
+            .add_operator_product(id, CalculatorComplex::new(1.0, 0.0))
             .unwrap();
 
         // Jordan-Wigner strings are inserted every second lowering (raising) operator, in even or
@@ -1332,11 +1332,8 @@ impl JordanWignerFermionToSpin for HermitianFermionProduct {
             let mut out = SpinHamiltonian::new();
             for (product, coeff) in spin_operator.iter() {
                 if coeff.im == 0.0.into() {
-                    out.add_operator_product(
-                        product.clone(),
-                        CalculatorFloat::from(coeff.re.clone() * 2),
-                    )
-                    .unwrap();
+                    out.add_operator_product(product.clone(), coeff.re.clone() * 2)
+                        .unwrap();
                 }
             }
             return out;

--- a/struqture/src/fermions/fermionic_indices.rs
+++ b/struqture/src/fermions/fermionic_indices.rs
@@ -1114,6 +1114,7 @@ impl GetValue<HermitianFermionProduct> for FermionProduct {
     ///
     /// # Arguments
     ///
+
     /// * `index` - The HermitianFermionProduct to transform the value by.
     /// * `value` - The value to be transformed.
     ///

--- a/struqture/src/fermions/fermionic_indices.rs
+++ b/struqture/src/fermions/fermionic_indices.rs
@@ -1295,8 +1295,6 @@ impl JordanWignerFermionToSpin for HermitianFermionProduct {
     ///
     /// `SpinHamiltonian` - The spin operator that results from the transformation.
     ///
-    /// * Unexpectedly failed to add a PauliProduct to a SpinOperator or SpinHamiltonian internal struqture bug.
-    ///
     /// # Panics
     ///
     /// * Internal bug in `add_operator_product`.
@@ -1357,17 +1355,17 @@ transform is hermitian.")
 fn _lowering_operator(i: &usize) -> SpinOperator {
     let mut out = SpinOperator::new();
     out.add_operator_product(PauliProduct::new().x(*i), CalculatorComplex::new(0.5, 0.0))
-        .unwrap();
+        .expect("Internal bug in add_operator_product.");
     out.add_operator_product(PauliProduct::new().y(*i), CalculatorComplex::new(0.0, -0.5))
-        .unwrap();
+        .expect("Internal bug in add_operator_product.");
     out
 }
 fn _raising_operator(i: &usize) -> SpinOperator {
     let mut out = SpinOperator::new();
     out.add_operator_product(PauliProduct::new().x(*i), CalculatorComplex::new(0.5, 0.0))
-        .unwrap();
+        .expect("Internal bug in add_operator_product.");
     out.add_operator_product(PauliProduct::new().y(*i), CalculatorComplex::new(0.0, 0.5))
-        .unwrap();
+        .expect("Internal bug in add_operator_product.");
     out
 }
 

--- a/struqture/src/fermions/fermionic_noise_operator.rs
+++ b/struqture/src/fermions/fermionic_noise_operator.rs
@@ -11,6 +11,8 @@
 // limitations under the License.
 
 use super::{FermionProduct, OperateOnFermions};
+use crate::mappings::JordanWignerFermionToSpin;
+use crate::spins::{DecoherenceProduct, SpinLindbladNoiseOperator};
 use crate::{
     ModeIndex, OperateOnDensityMatrix, OperateOnModes, StruqtureError, StruqtureVersionSerializable,
 };
@@ -458,6 +460,48 @@ impl fmt::Display for FermionLindbladNoiseOperator {
         output.push('}');
 
         write!(f, "{}", output)
+    }
+}
+
+impl JordanWignerFermionToSpin for FermionLindbladNoiseOperator {
+    type Output = SpinLindbladNoiseOperator;
+
+    /// Implements JordanWignerFermionToSpin for a FermionLindbladNoiseOperator.
+    ///
+    /// The convention used is that |0> represents an empty fermionic state (spin-orbital),
+    /// and |1> represents an occupied fermionic state.
+    ///
+    /// # Returns
+    ///
+    /// `SpinLindbladNoiseOperator` - The spin noise operator that results from the transformation.
+    fn jordan_wigner(&self) -> Self::Output {
+        let mut out = SpinLindbladNoiseOperator::new();
+
+        for key in self.keys() {
+            // TODO this can probably be done in one shot with pattern matching and .map()
+            let jw_fp_left = key.0.jordan_wigner();
+            let jw_fp_right = key.1.jordan_wigner();
+
+            for prod_left in jw_fp_left.keys() {
+                for prod_right in jw_fp_right.keys() {
+                    let (decoherence_prod_left, decoherence_coeff_left) =
+                        DecoherenceProduct::spin_to_decoherence(prod_left.clone());
+                    let (decoherence_prod_right, decoherence_coeff_right) =
+                        DecoherenceProduct::spin_to_decoherence(prod_right.clone());
+
+                    let new_coeff = self.get(key).clone()
+                        * CalculatorComplex::from(decoherence_coeff_right)
+                        * CalculatorComplex::from(decoherence_coeff_left)
+                        * jw_fp_left.get(prod_left)
+                        * jw_fp_right.get(prod_right);
+
+                    out.set((decoherence_prod_left, decoherence_prod_right), new_coeff)
+                        .unwrap();
+                }
+            }
+        }
+
+        out
     }
 }
 

--- a/struqture/src/fermions/fermionic_noise_operator.rs
+++ b/struqture/src/fermions/fermionic_noise_operator.rs
@@ -171,11 +171,7 @@ impl<'a> OperateOnDensityMatrix<'a> for FermionLindbladNoiseOperator {
         key: Self::Index,
         value: Self::Value,
     ) -> Result<Option<Self::Value>, StruqtureError> {
-        if key.0
-            == FermionProduct::new([], [])?
-            || key.1
-                == FermionProduct::new([], [])?
-        {
+        if key.0 == FermionProduct::new([], [])? || key.1 == FermionProduct::new([], [])? {
             return Err(StruqtureError::InvalidLindbladTerms);
         }
 

--- a/struqture/src/fermions/fermionic_noise_operator.rs
+++ b/struqture/src/fermions/fermionic_noise_operator.rs
@@ -167,8 +167,12 @@ impl<'a> OperateOnDensityMatrix<'a> for FermionLindbladNoiseOperator {
         key: Self::Index,
         value: Self::Value,
     ) -> Result<Option<Self::Value>, StruqtureError> {
-        if key.0 == FermionProduct::new([], []).unwrap()
-            || key.1 == FermionProduct::new([], []).unwrap()
+        if key.0
+            == FermionProduct::new([], [])
+                .expect("Internal error in creating empty FermionProduct.")
+            || key.1
+                == FermionProduct::new([], [])
+                    .expect("Internal error in creating empty FermionProduct.")
         {
             return Err(StruqtureError::InvalidLindbladTerms);
         }
@@ -198,8 +202,12 @@ impl<'a> OperateOnDensityMatrix<'a> for FermionLindbladNoiseOperator {
         key: Self::Index,
         value: Self::Value,
     ) -> Result<(), StruqtureError> {
-        if key.0 == FermionProduct::new([], []).unwrap()
-            || key.1 == FermionProduct::new([], []).unwrap()
+        if key.0
+            == FermionProduct::new([], [])
+                .expect("Internal error in creating empty FermionProduct.")
+            || key.1
+                == FermionProduct::new([], [])
+                    .expect("Internal error in creating empty FermionProduct.")
         {
             return Err(StruqtureError::InvalidLindbladTerms);
         }
@@ -537,7 +545,10 @@ impl JordanWignerFermionToSpin for FermionLindbladNoiseOperator {
     ///
     /// # Returns
     ///
-    /// `SpinLindbladNoiseOperator` - The spin noise operator that results from the transformation.
+    /// * `SpinLindbladNoiseOperator` - The spin noise operator that results from the transformation.
+    /// # Panics
+    ///
+    /// * Internal bug in add_noise_from_full_operators.
     fn jordan_wigner(&self) -> Self::Output {
         let mut out = SpinLindbladNoiseOperator::new();
 
@@ -550,7 +561,7 @@ impl JordanWignerFermionToSpin for FermionLindbladNoiseOperator {
                 &decoherence_operator_right,
                 self.get(key).into(),
             )
-            .unwrap();
+            .expect("Internal bug in add_noise_from_full_operators");
         }
         out
     }

--- a/struqture/src/fermions/fermionic_noise_operator.rs
+++ b/struqture/src/fermions/fermionic_noise_operator.rs
@@ -161,11 +161,18 @@ impl<'a> OperateOnDensityMatrix<'a> for FermionLindbladNoiseOperator {
     ///
     /// * `Ok(Some(CalculatorComplex))` - The key existed, this is the value it had before it was set with the value input.
     /// * `Ok(None)` - The key did not exist, it has been set with its corresponding value.
+    /// * `Err(StruqtureError)` - The input contained identities, which are not allowed as Lindblad operators.
     fn set(
         &mut self,
         key: Self::Index,
         value: Self::Value,
     ) -> Result<Option<Self::Value>, StruqtureError> {
+        if key.0 == FermionProduct::new([], []).unwrap()
+            || key.1 == FermionProduct::new([], []).unwrap()
+        {
+            return Err(StruqtureError::InvalidLindbladTerms);
+        }
+
         if value != CalculatorComplex::ZERO {
             Ok(self.internal_map.insert(key, value))
         } else {
@@ -174,6 +181,32 @@ impl<'a> OperateOnDensityMatrix<'a> for FermionLindbladNoiseOperator {
                 Entry::Vacant(_) => Ok(None),
             }
         }
+    }
+
+    /// Adds a new entry in the FermionLindbladNoiseOperator with the given ((FermionProduct, FermionProduct) key, CalculatorComplex value) pair.
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - The (FermionProduct, FermionProduct) key to set in the FermionLindbladNoiseOperator.
+    /// * `value` - The corresponding CalculatorComplex value to set for the key in the FermionLindbladNoiseOperator.
+    ///
+    /// # Returns
+    ///
+    /// * `Err(StruqtureError)` - The input contained identities, which are not allowed as Lindblad operators.
+    fn add_operator_product(
+        &mut self,
+        key: Self::Index,
+        value: Self::Value,
+    ) -> Result<(), StruqtureError> {
+        if key.0 == FermionProduct::new([], []).unwrap()
+            || key.1 == FermionProduct::new([], []).unwrap()
+        {
+            return Err(StruqtureError::InvalidLindbladTerms);
+        }
+
+        let old = self.get(&key).clone();
+        self.set(key, value + old)?;
+        Ok(())
     }
 }
 

--- a/struqture/src/fermions/fermionic_noise_operator.rs
+++ b/struqture/src/fermions/fermionic_noise_operator.rs
@@ -162,6 +162,10 @@ impl<'a> OperateOnDensityMatrix<'a> for FermionLindbladNoiseOperator {
     /// * `Ok(Some(CalculatorComplex))` - The key existed, this is the value it had before it was set with the value input.
     /// * `Ok(None)` - The key did not exist, it has been set with its corresponding value.
     /// * `Err(StruqtureError)` - The input contained identities, which are not allowed as Lindblad operators.
+    ///
+    /// # Panics
+    ///
+    /// * Internal error in FermionProduct::new
     fn set(
         &mut self,
         key: Self::Index,
@@ -169,10 +173,10 @@ impl<'a> OperateOnDensityMatrix<'a> for FermionLindbladNoiseOperator {
     ) -> Result<Option<Self::Value>, StruqtureError> {
         if key.0
             == FermionProduct::new([], [])
-                .expect("Internal error in creating empty FermionProduct.")
+                .expect("Internal error when creating empty FermionProduct.")
             || key.1
                 == FermionProduct::new([], [])
-                    .expect("Internal error in creating empty FermionProduct.")
+                    .expect("Internal error when creating empty FermionProduct.")
         {
             return Err(StruqtureError::InvalidLindbladTerms);
         }
@@ -185,36 +189,6 @@ impl<'a> OperateOnDensityMatrix<'a> for FermionLindbladNoiseOperator {
                 Entry::Vacant(_) => Ok(None),
             }
         }
-    }
-
-    /// Adds a new entry in the FermionLindbladNoiseOperator with the given ((FermionProduct, FermionProduct) key, CalculatorComplex value) pair.
-    ///
-    /// # Arguments
-    ///
-    /// * `key` - The (FermionProduct, FermionProduct) key to set in the FermionLindbladNoiseOperator.
-    /// * `value` - The corresponding CalculatorComplex value to set for the key in the FermionLindbladNoiseOperator.
-    ///
-    /// # Returns
-    ///
-    /// * `Err(StruqtureError)` - The input contained identities, which are not allowed as Lindblad operators.
-    fn add_operator_product(
-        &mut self,
-        key: Self::Index,
-        value: Self::Value,
-    ) -> Result<(), StruqtureError> {
-        if key.0
-            == FermionProduct::new([], [])
-                .expect("Internal error in creating empty FermionProduct.")
-            || key.1
-                == FermionProduct::new([], [])
-                    .expect("Internal error in creating empty FermionProduct.")
-        {
-            return Err(StruqtureError::InvalidLindbladTerms);
-        }
-
-        let old = self.get(&key).clone();
-        self.set(key, value + old)?;
-        Ok(())
     }
 }
 
@@ -546,6 +520,7 @@ impl JordanWignerFermionToSpin for FermionLindbladNoiseOperator {
     /// # Returns
     ///
     /// * `SpinLindbladNoiseOperator` - The spin noise operator that results from the transformation.
+    ///
     /// # Panics
     ///
     /// * Internal bug in add_noise_from_full_operators.

--- a/struqture/src/fermions/fermionic_noise_operator.rs
+++ b/struqture/src/fermions/fermionic_noise_operator.rs
@@ -161,7 +161,7 @@ impl<'a> OperateOnDensityMatrix<'a> for FermionLindbladNoiseOperator {
     ///
     /// * `Ok(Some(CalculatorComplex))` - The key existed, this is the value it had before it was set with the value input.
     /// * `Ok(None)` - The key did not exist, it has been set with its corresponding value.
-    /// * `Err(StruqtureError)` - The input contained identities, which are not allowed as Lindblad operators.
+    /// * `Err(StruqtureError::InvalidLindbladTerms)` - The input contained identities, which are not allowed as Lindblad operators.
     ///
     /// # Panics
     ///
@@ -172,11 +172,9 @@ impl<'a> OperateOnDensityMatrix<'a> for FermionLindbladNoiseOperator {
         value: Self::Value,
     ) -> Result<Option<Self::Value>, StruqtureError> {
         if key.0
-            == FermionProduct::new([], [])
-                .expect("Internal error when creating empty FermionProduct.")
+            == FermionProduct::new([], [])?
             || key.1
-                == FermionProduct::new([], [])
-                    .expect("Internal error when creating empty FermionProduct.")
+                == FermionProduct::new([], [])?
         {
             return Err(StruqtureError::InvalidLindbladTerms);
         }

--- a/struqture/src/fermions/fermionic_noise_system.rs
+++ b/struqture/src/fermions/fermionic_noise_system.rs
@@ -11,6 +11,8 @@
 // limitations under the License.
 
 use super::{FermionLindbladNoiseOperator, OperateOnFermions};
+use crate::mappings::JordanWignerFermionToSpin;
+use crate::spins::SpinLindbladNoiseSystem;
 use crate::{ModeIndex, OperateOnDensityMatrix, OperateOnModes, StruqtureError};
 use qoqo_calculator::CalculatorComplex;
 use serde::{Deserialize, Serialize};
@@ -457,5 +459,25 @@ impl fmt::Display for FermionLindbladNoiseSystem {
         output.push('}');
 
         write!(f, "{}", output)
+    }
+}
+
+impl JordanWignerFermionToSpin for FermionLindbladNoiseSystem {
+    type Output = SpinLindbladNoiseSystem;
+
+    /// Implements JordanWignerFermionToSpin for a FermionLindbladNoiseSystem.
+    ///
+    /// The convention used is that |0> represents an empty fermionic state (spin-orbital),
+    /// and |1> represents an occupied fermionic state.
+    ///
+    /// # Returns
+    ///
+    /// `SpinLindbladNoiseSystem` - The spin noise operator that results from the transformation.
+    fn jordan_wigner(&self) -> Self::Output {
+        SpinLindbladNoiseSystem::from_operator(
+            self.operator().jordan_wigner(),
+            Some(self.number_modes()),
+        )
+        .unwrap()
     }
 }

--- a/struqture/src/fermions/fermionic_noise_system.rs
+++ b/struqture/src/fermions/fermionic_noise_system.rs
@@ -504,11 +504,14 @@ impl JordanWignerFermionToSpin for FermionLindbladNoiseSystem {
     /// # Returns
     ///
     /// `SpinLindbladNoiseSystem` - The spin noise operator that results from the transformation.
+    /// # Panics
+    ///
+    /// * Internal error in jordan_wigner transformation for FermionLindbladNoiseOperator.
     fn jordan_wigner(&self) -> Self::Output {
         SpinLindbladNoiseSystem::from_operator(
             self.operator().jordan_wigner(),
             Some(self.number_modes()),
         )
-        .unwrap()
+            .expect("Internal bug in jordan_wigner for FermionLindbladNoiseOperator. The number of spins in the resulting SpinLindbladNoiseOperator should equal the number of modes of the FermionLindbladNoiseOperator.")
     }
 }

--- a/struqture/src/fermions/fermionic_noise_system.rs
+++ b/struqture/src/fermions/fermionic_noise_system.rs
@@ -504,6 +504,7 @@ impl JordanWignerFermionToSpin for FermionLindbladNoiseSystem {
     /// # Returns
     ///
     /// `SpinLindbladNoiseSystem` - The spin noise operator that results from the transformation.
+    ///
     /// # Panics
     ///
     /// * Internal error in jordan_wigner transformation for FermionLindbladNoiseOperator.

--- a/struqture/src/fermions/fermionic_open_system.rs
+++ b/struqture/src/fermions/fermionic_open_system.rs
@@ -11,6 +11,8 @@
 // limitations under the License.
 
 use super::{FermionHamiltonianSystem, FermionLindbladNoiseSystem};
+use crate::mappings::JordanWignerFermionToSpin;
+use crate::spins::SpinLindbladOpenSystem;
 use crate::{OpenSystem, OperateOnDensityMatrix, OperateOnModes, StruqtureError};
 use qoqo_calculator::CalculatorFloat;
 use serde::{Deserialize, Serialize};
@@ -253,5 +255,23 @@ impl fmt::Display for FermionLindbladOpenSystem {
         output.push('}');
 
         write!(f, "{}", output)
+    }
+}
+
+impl JordanWignerFermionToSpin for FermionLindbladOpenSystem {
+    type Output = SpinLindbladOpenSystem;
+
+    /// Implements JordanWignerFermionToSpin for a FermionLindbladOpenSystem.
+    ///
+    /// The convention used is that |0> represents an empty fermionic state (spin-orbital),
+    /// and |1> represents an occupied fermionic state.
+    ///
+    /// # Returns
+    ///
+    /// `SpinLindbladOpenSystem` - The spin noise operator that results from the transformation.
+    fn jordan_wigner(&self) -> Self::Output {
+        let jw_system = self.system().jordan_wigner();
+        let jw_noise = self.noise().jordan_wigner();
+        SpinLindbladOpenSystem::group(jw_system, jw_noise).unwrap()
     }
 }

--- a/struqture/src/fermions/fermionic_operator.rs
+++ b/struqture/src/fermions/fermionic_operator.rs
@@ -510,11 +510,10 @@ impl JordanWignerFermionToSpin for FermionOperator {
     fn jordan_wigner(&self) -> Self::Output {
         let mut out = SpinOperator::new();
         for fp in self.keys() {
-            out = out + fp.jordan_wigner()*self.get(fp);
+            out = out + fp.jordan_wigner() * self.get(fp);
         }
         out
     }
-
 }
 
 #[cfg(test)]

--- a/struqture/src/fermions/fermionic_operator.rs
+++ b/struqture/src/fermions/fermionic_operator.rs
@@ -12,6 +12,8 @@
 
 use super::{FermionHamiltonian, OperateOnFermions};
 use crate::fermions::FermionProduct;
+use crate::mappings::JordanWignerFermionToSpin;
+use crate::spins::SpinOperator;
 use crate::{
     GetValue, ModeIndex, OperateOnDensityMatrix, OperateOnModes, OperateOnState, StruqtureError,
     StruqtureVersionSerializable, SymmetricIndex,
@@ -492,6 +494,29 @@ impl fmt::Display for FermionOperator {
 
         write!(f, "{}", output)
     }
+}
+
+impl JordanWignerFermionToSpin for FermionOperator {
+    type Output = SpinOperator;
+
+    /// Implements JordanWignerFermionToSpin for a FermionOperator.
+    ///
+    /// The convention used is that |0> represents an empty fermionic state (spin-orbital),
+    /// and |1> represents an occupied fermionic state.
+    ///
+    /// # Returns
+    ///
+    /// `SpinOperator` - The spin operator that results from the transformation.
+    fn jordan_wigner(&self) -> Self::Output {
+        let mut out = SpinOperator::new();
+        for fp in self.keys() {
+            out = out + fp.jordan_wigner()*self.get(fp);
+        }
+        out
+    }
+
+
+
 }
 
 #[cfg(test)]

--- a/struqture/src/fermions/fermionic_operator.rs
+++ b/struqture/src/fermions/fermionic_operator.rs
@@ -515,8 +515,6 @@ impl JordanWignerFermionToSpin for FermionOperator {
         out
     }
 
-
-
 }
 
 #[cfg(test)]

--- a/struqture/src/fermions/fermionic_system.rs
+++ b/struqture/src/fermions/fermionic_system.rs
@@ -12,6 +12,8 @@
 
 use super::{FermionOperator, OperateOnFermions};
 use crate::fermions::FermionProduct;
+use crate::mappings::JordanWignerFermionToSpin;
+use crate::spins::SpinSystem;
 use crate::{ModeIndex, OperateOnDensityMatrix, OperateOnModes, OperateOnState, StruqtureError};
 use qoqo_calculator::CalculatorComplex;
 use serde::{Deserialize, Serialize};
@@ -495,5 +497,28 @@ impl fmt::Display for FermionSystem {
         output.push('}');
 
         write!(f, "{}", output)
+    }
+}
+
+impl JordanWignerFermionToSpin for FermionSystem {
+    type Output = SpinSystem;
+
+    /// Implements JordanWignerFermionToSpin for a FermionSystem.
+    ///
+    /// The convention used is that |0> represents an empty fermionic state (spin-orbital),
+    /// and |1> represents an occupied fermionic state.
+    ///
+    /// # Returns
+    ///
+    /// `SpinSystem` - The spin noise operator that results from the transformation.
+    /// # Panics
+    ///
+    /// * Internal error in jordan_wigner transformation for FermionHamiltonian.
+    fn jordan_wigner(&self) -> Self::Output {
+        SpinSystem::from_operator(
+            self.operator().jordan_wigner(),
+            Some(self.number_modes()),
+        )
+            .expect("Internal bug in jordan_wigner for FermionSystem. The number of spins in the resulting SpinSystem should equal the number of modes of the FermionSystem.")
     }
 }

--- a/struqture/src/lib.rs
+++ b/struqture/src/lib.rs
@@ -1002,6 +1002,7 @@ pub mod fermions;
 pub mod mixed_systems;
 pub mod prelude;
 pub mod spins;
+pub mod mappings;
 
 /// Shorhand type for TinyVec representation of creators or annihilators
 #[cfg(test)]

--- a/struqture/src/lib.rs
+++ b/struqture/src/lib.rs
@@ -999,10 +999,10 @@ type CreatorsAnnihilators = (TinyVec<[usize; 2]>, TinyVec<[usize; 2]>);
 
 pub mod bosons;
 pub mod fermions;
+pub mod mappings;
 pub mod mixed_systems;
 pub mod prelude;
 pub mod spins;
-pub mod mappings;
 
 /// Shorhand type for TinyVec representation of creators or annihilators
 #[cfg(test)]

--- a/struqture/src/lib.rs
+++ b/struqture/src/lib.rs
@@ -135,7 +135,7 @@ impl From<StruqtureVersion> for StruqtureVersionSerializable {
     }
 }
 
-/// Errors that can occur in roqoqo.
+/// Errors that can occur in struqture.
 #[derive(Debug, Error, PartialEq)]
 pub enum StruqtureError {
     /// Error when remapping qubits fails because qubit in operation is not in keys of BTreeMap.
@@ -236,6 +236,9 @@ pub enum StruqtureError {
     /// Transparent propagation of CalculatorError.
     #[error(transparent)]
     CalculatorError(#[from] CalculatorError),
+    /// Error when trying to insert identities into noise operators
+    #[error("Lindblad operators need to be traceless.")]
+    InvalidLindbladTerms,
 }
 
 /// Complex sparse matrix in coordinate (COO) format.

--- a/struqture/src/mappings/jordan_wigner.rs
+++ b/struqture/src/mappings/jordan_wigner.rs
@@ -17,27 +17,24 @@
 //!
 //! $$ JW(a_p^{\dagger}) = \left[ \prod_{i = 1}^{p - 1} Z_i \right] \left( \frac{X_p - i Y_p}{2}
 //! \right) $$
-//! 
+//!
 //! $$ JW(a_p) = \left[ \prod_{i = 1}^{p - 1} Z_i \right] \left( \frac{X_p + i Y_p}{2} \right) $$
 
-
-pub trait JordanWignerFermionToSpin{
-
+pub trait JordanWignerFermionToSpin {
     /// The Output type for the JordanWigner transformation
     ///
     /// For a FermionProduct, HermitianFermionProduct or FermionOperator it will be a SpinOperator
     /// For a FermionHamiltonian it will be a SpinHamiltonian
+    /// For a FermionLindbladNoiseOperator it will be a SpinLindbladNoiseOperator
     /// For a FermionLindbladOpenSystem it will be a SpinLindbladOpenSystem etc.
     type Output;
 
     /// Transform the given fermionic object into a spin object using
     /// the Jordan Wigner mapping.
     fn jordan_wigner(&self) -> Self::Output;
-
 }
 
-pub trait JordanWignerSpinToFermion{
-
+pub trait JordanWignerSpinToFermion {
     /// The Output type for the JordanWigner transformation
     ///
     /// TODO missing PauliOperator
@@ -50,6 +47,4 @@ pub trait JordanWignerSpinToFermion{
     /// Transform the given fermionic object into a spin object using
     /// the Jordan Wigner mapping.
     fn jordan_wigner(self) -> Self::Output;
-
 }
-

--- a/struqture/src/mappings/jordan_wigner.rs
+++ b/struqture/src/mappings/jordan_wigner.rs
@@ -35,7 +35,7 @@ use crate::spins::{
     SpinHamiltonian,
     SpinLindbladOpenSystem,
     SingleSpinOperator,
-}
+};
 use crate::prelude::*;
 use qoqo_calculator::CalculatorComplex;
 
@@ -71,61 +71,3 @@ pub trait JordanWignerSpinToFermion{
 
 }
 
-fn _lowering_operator(i: &usize) -> SpinOperator {
-    let mut out = SpinOperator::new();
-    out.add_operator_product(PauliProduct::new().x(*i), CalculatorComplex::new(0.5, 0.0)).unwrap();
-    out.add_operator_product(PauliProduct::new().y(*i), CalculatorComplex::new(0.0, -0.5)).unwrap();
-    out
-}
-fn _raising_operator(i: &usize) -> SpinOperator {
-    let mut out = SpinOperator::new();
-    out.add_operator_product(PauliProduct::new().x(*i), CalculatorComplex::new(0.5, 0.0)).unwrap();
-    out.add_operator_product(PauliProduct::new().y(*i), CalculatorComplex::new(0.0, 0.5)).unwrap();
-    out
-}
-
-
-impl JordanWignerFermionToSpin for FermionProduct {
-    type Output = SpinOperator;
-
-    /// TODO docstring explaining simplifications
-    fn jordan_wigner(self) -> Self::Output {
-        let number_creators = self.number_creators();
-        let number_annihilators = self.number_annihilators();
-        let mut out = SpinOperator::new();
-
-        // initialize out with an identity
-        let mut id = PauliProduct::new();
-        id = id.set_pauli(0, SingleSpinOperator::Identity);
-        out.add_operator_product(id.clone(), CalculatorComplex::new(1.0, 0.0)).unwrap();
-        
-        // TODO add check that input is not the identity?
-        // or see if it works fine already
-
-        let mut previous = 0;
-        for (index, site) in self.creators().enumerate() {
-            // insert Jordan-Wigner string
-            if index%2 != number_creators%2 {
-                for i in previous..*site {                    
-                    out = out * PauliProduct::new().z(i)
-                }
-            }
-            out = out * _lowering_operator(site);
-            previous = *site;
-        }
-
-        previous = 0;
-        for (index, site) in self.annihilators().enumerate() {
-            // insert Jordan-Wigner string
-            if index%2 != number_annihilators%2 {
-                for i in previous..*site {                    
-                    out = out * PauliProduct::new().z(i)
-                }
-            }
-            out = out * _raising_operator(site);
-            previous = *site;
-        }
-        out
-
-    }
-}

--- a/struqture/src/mappings/jordan_wigner.rs
+++ b/struqture/src/mappings/jordan_wigner.rs
@@ -35,8 +35,7 @@ pub trait JordanWignerFermionToSpin {
 pub trait JordanWignerSpinToFermion {
     /// The Output type for the JordanWigner transformation
     ///
-    /// TODO missing PauliOperator
-    /// For a SpinOperator it will be a FermionOperator
+    /// For a PauliProduct or SpinOperator it will be a FermionOperator
     /// For a SpinHamiltonian it will be a FermionHamiltonian
     /// For a SpinLindbladOpenSystem it will be a FermionLindbladOpenSystem
     /// etc.

--- a/struqture/src/mappings/jordan_wigner.rs
+++ b/struqture/src/mappings/jordan_wigner.rs
@@ -50,7 +50,7 @@ pub trait JordanWignerFermionToSpin{
 
     /// Transform the given fermionic object into a spin object using
     /// the Jordan Wigner mapping.
-    fn jordan_wigner(self) -> Self::Output;
+    fn jordan_wigner(&self) -> Self::Output;
 
 }
 

--- a/struqture/src/mappings/jordan_wigner.rs
+++ b/struqture/src/mappings/jordan_wigner.rs
@@ -21,24 +21,6 @@
 //! $$ JW(a_p) = \left[ \prod_{i = 1}^{p - 1} Z_i \right] \left( \frac{X_p + i Y_p}{2} \right) $$
 
 
-use crate::OperateOnDensityMatrix;
-use crate::fermions::{
-    FermionProduct,
-    HermitianFermionProduct,
-    FermionOperator,
-    FermionHamiltonian,
-    FermionLindbladOpenSystem,
-};
-use crate::spins::{
-    PauliProduct,
-    SpinOperator,
-    SpinHamiltonian,
-    SpinLindbladOpenSystem,
-    SingleSpinOperator,
-};
-use crate::prelude::*;
-use qoqo_calculator::CalculatorComplex;
-
 pub trait JordanWignerFermionToSpin{
 
     /// The Output type for the JordanWigner transformation

--- a/struqture/src/mappings/jordan_wigner.rs
+++ b/struqture/src/mappings/jordan_wigner.rs
@@ -1,0 +1,131 @@
+// Copyright © 2020-2022 HQS Quantum Simulations GmbH. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the
+// License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Jordan-Wigner mapping between fermionic operators and spin operators.
+//!
+//! The convention used is to treat the qubit state $|0 \rangle$ as empty, and the state $|1\rangle$
+//! as occupied by a fermion. The corresponding mapping is given by
+//!
+//! $$ JW(a_p^{\dagger}) = \left[ \prod_{i = 1}^{p - 1} Z_i \right] \left( \frac{X_p - i Y_p}{2}
+//! \right) $$
+//! 
+//! $$ JW(a_p) = \left[ \prod_{i = 1}^{p - 1} Z_i \right] \left( \frac{X_p + i Y_p}{2} \right) $$
+
+
+use crate::OperateOnDensityMatrix;
+use crate::fermions::{
+    FermionProduct,
+    HermitianFermionProduct,
+    FermionOperator,
+    FermionHamiltonian,
+    FermionLindbladOpenSystem,
+};
+use crate::spins::{
+    PauliProduct,
+    SpinOperator,
+    SpinHamiltonian,
+    SpinLindbladOpenSystem,
+    SingleSpinOperator,
+}
+use crate::prelude::*;
+use qoqo_calculator::CalculatorComplex;
+
+pub trait JordanWignerFermionToSpin{
+
+    /// The Output type for the JordanWigner transformation
+    ///
+    /// For a FermionProduct, HermitianFermionProduct or FermionOperator it will be a SpinOperator
+    /// For a FermionHamiltonian it will be a SpinHamiltonian
+    /// For a FermionLindbladOpenSystem it will be a SpinLindbladOpenSystem etc.
+    type Output;
+
+    /// Transform the given fermionic object into a spin object using
+    /// the Jordan Wigner mapping.
+    fn jordan_wigner(self) -> Self::Output;
+
+}
+
+pub trait JordanWignerSpinToFermion{
+
+    /// The Output type for the JordanWigner transformation
+    ///
+    /// TODO missing PauliOperator
+    /// For a SpinOperator it will be a FermionOperator
+    /// For a SpinHamiltonian it will be a FermionHamiltonian
+    /// For a SpinLindbladOpenSystem it will be a FermionLindbladOpenSystem
+    /// etc.
+    type Output;
+
+    /// Transform the given fermionic object into a spin object using
+    /// the Jordan Wigner mapping.
+    fn jordan_wigner(self) -> Self::Output;
+
+}
+
+fn _lowering_operator(i: &usize) -> SpinOperator {
+    let mut out = SpinOperator::new();
+    out.add_operator_product(PauliProduct::new().x(*i), CalculatorComplex::new(0.5, 0.0)).unwrap();
+    out.add_operator_product(PauliProduct::new().y(*i), CalculatorComplex::new(0.0, -0.5)).unwrap();
+    out
+}
+fn _raising_operator(i: &usize) -> SpinOperator {
+    let mut out = SpinOperator::new();
+    out.add_operator_product(PauliProduct::new().x(*i), CalculatorComplex::new(0.5, 0.0)).unwrap();
+    out.add_operator_product(PauliProduct::new().y(*i), CalculatorComplex::new(0.0, 0.5)).unwrap();
+    out
+}
+
+
+impl JordanWignerFermionToSpin for FermionProduct {
+    type Output = SpinOperator;
+
+    /// TODO docstring explaining simplifications
+    fn jordan_wigner(self) -> Self::Output {
+        let number_creators = self.number_creators();
+        let number_annihilators = self.number_annihilators();
+        let mut out = SpinOperator::new();
+
+        // initialize out with an identity
+        let mut id = PauliProduct::new();
+        id = id.set_pauli(0, SingleSpinOperator::Identity);
+        out.add_operator_product(id.clone(), CalculatorComplex::new(1.0, 0.0)).unwrap();
+        
+        // TODO add check that input is not the identity?
+        // or see if it works fine already
+
+        let mut previous = 0;
+        for (index, site) in self.creators().enumerate() {
+            // insert Jordan-Wigner string
+            if index%2 != number_creators%2 {
+                for i in previous..*site {                    
+                    out = out * PauliProduct::new().z(i)
+                }
+            }
+            out = out * _lowering_operator(site);
+            previous = *site;
+        }
+
+        previous = 0;
+        for (index, site) in self.annihilators().enumerate() {
+            // insert Jordan-Wigner string
+            if index%2 != number_annihilators%2 {
+                for i in previous..*site {                    
+                    out = out * PauliProduct::new().z(i)
+                }
+            }
+            out = out * _raising_operator(site);
+            previous = *site;
+        }
+        out
+
+    }
+}

--- a/struqture/src/mappings/jordan_wigner.rs
+++ b/struqture/src/mappings/jordan_wigner.rs
@@ -15,10 +15,8 @@
 //! The convention used is to treat the qubit state $|0 \rangle$ as empty, and the state $|1\rangle$
 //! as occupied by a fermion. The corresponding mapping is given by
 //!
-//! $$ JW(a_p^{\dagger}) = \left[ \prod_{i = 1}^{p - 1} Z_i \right] \left( \frac{X_p - i Y_p}{2}
-//! \right) $$
-//!
-//! $$ JW(a_p) = \left[ \prod_{i = 1}^{p - 1} Z_i \right] \left( \frac{X_p + i Y_p}{2} \right) $$
+//! JW(a_p^{dagger}) = ( \prod_{i = 1}^{p - 1} Z_i )(X_p - i Y_p)*1/2
+//! JW(a_p) = ( \prod_{i = 1}^{p - 1} Z_i )(X_p + i Y_p)*1/2
 
 pub trait JordanWignerFermionToSpin {
     /// The Output type for the JordanWigner transformation

--- a/struqture/src/mappings/mod.rs
+++ b/struqture/src/mappings/mod.rs
@@ -1,0 +1,18 @@
+// Copyright © 2020-2022 HQS Quantum Simulations GmbH. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the
+// License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+//! Module for representing mappings between systems of bosons, fermions and spins.
+
+pub mod jordan_wigner;
+
+

--- a/struqture/src/mappings/mod.rs
+++ b/struqture/src/mappings/mod.rs
@@ -15,4 +15,7 @@
 
 pub mod jordan_wigner;
 
+pub use jordan_wigner::JordanWignerFermionToSpin;
+pub use jordan_wigner::JordanWignerSpinToFermion;
+
 

--- a/struqture/src/mappings/mod.rs
+++ b/struqture/src/mappings/mod.rs
@@ -10,12 +10,9 @@
 // express or implied. See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 //! Module for representing mappings between systems of bosons, fermions and spins.
 
 pub mod jordan_wigner;
 
 pub use jordan_wigner::JordanWignerFermionToSpin;
 pub use jordan_wigner::JordanWignerSpinToFermion;
-
-

--- a/struqture/src/spins/decoherence_operator.rs
+++ b/struqture/src/spins/decoherence_operator.rs
@@ -10,7 +10,7 @@
 // express or implied. See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::OperateOnSpins;
+use super::{OperateOnSpins, SpinOperator};
 use crate::spins::DecoherenceProduct;
 use crate::{
     OperateOnDensityMatrix, OperateOnState, SpinIndex, StruqtureError,
@@ -465,6 +465,31 @@ impl fmt::Display for DecoherenceOperator {
         output.push('}');
 
         write!(f, "{}", output)
+    }
+}
+
+impl From<SpinOperator> for DecoherenceOperator {
+    /// Converts a SpinOperator into a DecoherenceProduct.
+    ///
+    /// # Arguments
+    ///
+    /// * `op` - The SpinOperator to convert.
+    ///
+    /// # Returns
+    ///
+    /// * `Self` - The SpinOperator converted into a DecoherenceProduct.
+    ///
+    /// # Panics
+    ///
+    /// * Internal error in add_operator_product.
+    fn from(op: SpinOperator) -> Self {
+        let mut out = DecoherenceOperator::new();
+        for prod in op.keys() {
+            let (new_prod, new_coeff) = DecoherenceProduct::spin_to_decoherence(prod.clone());
+            out.add_operator_product(new_prod, op.get(prod).clone() * new_coeff)
+                .expect("Internal error in add_operator_product");
+        }
+        out
     }
 }
 

--- a/struqture/src/spins/spin_noise_operator.rs
+++ b/struqture/src/spins/spin_noise_operator.rs
@@ -182,30 +182,6 @@ impl<'a> OperateOnDensityMatrix<'a> for SpinLindbladNoiseOperator {
             }
         }
     }
-
-    /// Adds a new entry in the SpinLindbladNoiseOperator with the given ((DecoherenceProduct, DecoherenceProduct) key, CalculatorComplex value) pair.
-    ///
-    /// # Arguments
-    ///
-    /// * `key` - The (DecoherenceProduct, DecoherenceProduct) key to set in the SpinLindbladNoiseOperator.
-    /// * `value` - The corresponding CalculatorComplex value to set for the key in the SpinLindbladNoiseOperator.
-    ///
-    /// # Returns
-    ///
-    /// * `Err(StruqtureError)` - The input contained identities, which are not allowed as Lindblad operators.
-    fn add_operator_product(
-        &mut self,
-        key: Self::Index,
-        value: Self::Value,
-    ) -> Result<(), StruqtureError> {
-        if key.0.is_empty() || key.1.is_empty() {
-            return Err(StruqtureError::InvalidLindbladTerms);
-        }
-
-        let old = self.get(&key).clone();
-        self.set(key, value + old)?;
-        Ok(())
-    }
 }
 
 impl<'a> OperateOnSpins<'a> for SpinLindbladNoiseOperator {
@@ -345,6 +321,7 @@ impl SpinLindbladNoiseOperator {
     ///
     /// * `Ok(())` - The noise was correctly added.
     /// * `Err(StruqtureError::NumberSpinsExceeded)` - Number of spins in entry exceeds number of spins in system.
+    /// * `Err(StruqtureError::InvalidLindbladTerms)` - The input contained identities, which are not allowed as Lindblad operators.
     pub fn add_noise_from_full_operators(
         &mut self,
         left: &DecoherenceOperator,

--- a/struqture/src/spins/spin_noise_operator.rs
+++ b/struqture/src/spins/spin_noise_operator.rs
@@ -351,9 +351,8 @@ impl SpinLindbladNoiseOperator {
         right: &DecoherenceOperator,
         value: CalculatorComplex,
     ) -> Result<(), StruqtureError> {
-
         if left.is_empty() || right.is_empty() {
-            return Err(StruqtureError::InvalidLindbladTerms)
+            return Err(StruqtureError::InvalidLindbladTerms);
         }
 
         for ((decoherence_product_left, value_left), (decoherence_product_right, value_right)) in

--- a/struqture/src/spins/spin_noise_operator.rs
+++ b/struqture/src/spins/spin_noise_operator.rs
@@ -310,7 +310,8 @@ impl SpinLindbladNoiseOperator {
     /// # Arguments
     ///
     /// * `left` - DecoherenceOperator that acts on the density matrix from the left in the Lindblad equation.
-    /// * `value` -  DecoherenceOperator that acts on the density matrix from the right and in hermitian conjugated form in the Lindblad equation.
+    /// * `right` -  DecoherenceOperator that acts on the density matrix from the right and in hermitian conjugated form in the Lindblad equation.
+    /// * `value` - CalculatorComplex value representing the global coefficient of the noise term.
     ///
     /// # Returns
     ///

--- a/struqture/tests/bosons/bosonic_noise_operator.rs
+++ b/struqture/tests/bosons/bosonic_noise_operator.rs
@@ -339,6 +339,29 @@ fn into_iter_from_iter_extend() {
     assert_eq!(so_0, so_0_1);
 }
 
+// Test the failure of creating the BosonLindbladNoiseOperator with identity terms
+#[test]
+fn illegal_identity_operators() {
+    let empty_fp = BosonProduct::new([], []).unwrap();
+    let fp = BosonProduct::new([0], [1]).unwrap();
+    let mut fno_left_identity = BosonLindbladNoiseOperator::new();
+    let cc = CalculatorComplex::new(1.0, 1.0);
+    let ok = fno_left_identity
+        .add_operator_product((empty_fp.clone(), fp.clone()), cc.clone())
+        .is_err();
+    assert!(ok);
+    let mut fno_right_identity = BosonLindbladNoiseOperator::new();
+    let ok = fno_right_identity
+        .add_operator_product((fp.clone(), empty_fp.clone()), cc.clone())
+        .is_err();
+    assert!(ok);
+    let mut fno_both_identity = BosonLindbladNoiseOperator::new();
+    let ok = fno_both_identity
+        .add_operator_product((empty_fp.clone(), empty_fp.clone()), cc)
+        .is_err();
+    assert!(ok);
+}
+
 // Test the Debug trait of BosonLindbladNoiseOperator
 #[test]
 fn debug() {

--- a/struqture/tests/fermions/fermionic_noise_operator.rs
+++ b/struqture/tests/fermions/fermionic_noise_operator.rs
@@ -363,6 +363,29 @@ fn into_iter_from_iter_extend() {
     assert_eq!(so_0, so_0_1);
 }
 
+// Test the failure of creating the FermionLindbladNoiseOperator with identity terms
+#[test]
+fn illegal_identity_operators() {
+    let empty_fp = FermionProduct::new([], []).unwrap();
+    let fp = FermionProduct::new([0], [1]).unwrap();
+    let mut fno_left_identity = FermionLindbladNoiseOperator::new();
+    let cc = CalculatorComplex::new(1.0, 1.0);
+    let ok = fno_left_identity
+        .add_operator_product((empty_fp.clone(), fp.clone()), cc.clone())
+        .is_err();
+    assert!(ok);
+    let mut fno_right_identity = FermionLindbladNoiseOperator::new();
+    let ok = fno_right_identity
+        .add_operator_product((fp.clone(), empty_fp.clone()), cc.clone())
+        .is_err();
+    assert!(ok);
+    let mut fno_both_identity = FermionLindbladNoiseOperator::new();
+    let ok = fno_both_identity
+        .add_operator_product((empty_fp.clone(), empty_fp.clone()), cc)
+        .is_err();
+    assert!(ok);
+}
+
 // Test the Debug trait of FermionLindbladNoiseOperator
 #[test]
 fn debug() {

--- a/struqture/tests/main.rs
+++ b/struqture/tests/main.rs
@@ -25,3 +25,6 @@ mod spins;
 
 #[cfg(test)]
 mod mixed_systems;
+
+#[cfg(test)]
+mod mappings;

--- a/struqture/tests/mappings/jordan_wigner.rs
+++ b/struqture/tests/mappings/jordan_wigner.rs
@@ -10,14 +10,19 @@
 // express or implied. See the License for the specific language governing permissions and
 // limitations under the License.
 
-use qoqo_calculator::CalculatorComplex;
-
+use qoqo_calculator::{
+    CalculatorComplex,
+    CalculatorFloat,
+};
 use struqture::prelude::*;
 use struqture::fermions::{
     FermionProduct,
     HermitianFermionProduct,
+    FermionOperator,
+    FermionHamiltonian,
 };
 use struqture::spins::{PauliProduct,
+                       SpinHamiltonian,
                        SpinOperator,
                        SingleSpinOperator,
 };
@@ -64,10 +69,34 @@ fn test_jw_hermitian_fermion_product_to_spin() {
 
 #[test]
 fn test_jw_fermion_operator_to_spin() {
-    // TODO
+
+    let mut fo = FermionOperator::new();
+    let fp1 = FermionProduct::new([1, 2], [2, 3]).unwrap();
+    let fp2 = FermionProduct::new([3, 4], [2, 5]).unwrap();
+    fo.add_operator_product(fp1.clone(), CalculatorComplex::new(1.0, 2.0)).unwrap();
+    fo.add_operator_product(fp2.clone(), CalculatorComplex::new(2.0, 1.0)).unwrap();
+    let jw_pair1 = fp1.jordan_wigner()*CalculatorComplex::new(1.0, 2.0);
+    let jw_pair2 = fp2.jordan_wigner()*CalculatorComplex::new(2.0, 1.0);
+
+    assert_eq!(fo.jordan_wigner(), jw_pair1 + jw_pair2);
 }
 
 #[test]
 fn test_jw_fermion_hamiltonian_to_spin() {
-    // TODO 
+
+    let mut fh = FermionHamiltonian::new();
+    let hfp1 = HermitianFermionProduct::new([1, 2], [2, 4]).unwrap();
+    let hfp2 = HermitianFermionProduct::new([1, 3], [1, 2]).unwrap();
+    fh.add_operator_product(hfp1.clone(), 1.0.into()).unwrap();
+    fh.add_operator_product(hfp2.clone(), 2.0.into()).unwrap();
+    let jw_pair1 = hfp1.jordan_wigner();
+    let jw_pair2 = hfp2.jordan_wigner();
+    let jw_pair1_hamiltonian = SpinHamiltonian::try_from(jw_pair1).unwrap();
+    let jw_pair2_hamiltonian = SpinHamiltonian::try_from(jw_pair2).unwrap();
+
+    assert_eq!(fh.jordan_wigner(),
+               jw_pair1_hamiltonian*CalculatorFloat::from(1.0) + 
+               jw_pair2_hamiltonian*CalculatorFloat::from(2.0)
+    );
+
 }

--- a/struqture/tests/mappings/jordan_wigner.rs
+++ b/struqture/tests/mappings/jordan_wigner.rs
@@ -19,9 +19,8 @@ use struqture::fermions::{
 use struqture::mappings::JordanWignerFermionToSpin;
 use struqture::prelude::*;
 use struqture::spins::{
-    DecoherenceProduct, PauliProduct, SingleSpinOperator,
-    SpinHamiltonian, SpinHamiltonianSystem, SpinLindbladNoiseOperator, SpinLindbladNoiseSystem,
-    SpinLindbladOpenSystem, SpinOperator,
+    DecoherenceProduct, PauliProduct, SingleSpinOperator, SpinHamiltonian, SpinHamiltonianSystem,
+    SpinLindbladNoiseOperator, SpinLindbladNoiseSystem, SpinLindbladOpenSystem, SpinOperator,
 };
 
 #[test]
@@ -64,12 +63,24 @@ fn test_jw_hermitian_fermion_product_to_spin() {
     so.add_operator_product(pp_2.clone(), CalculatorFloat::from(0.5))
         .unwrap();
 
-    assert_eq!(hfp.jordan_wigner(), so)
+    assert_eq!(hfp.jordan_wigner(), so);
+
+    let hfp = HermitianFermionProduct::new([], []).unwrap();
+    let mut so = SpinHamiltonian::new();
+    let mut id = PauliProduct::new();
+    id = id.set_pauli(0, SingleSpinOperator::Identity);
+    so.add_operator_product(id.clone(), 1.0.into()).unwrap();
+
+    assert_eq!(hfp.jordan_wigner(), so);
 }
 
 #[test]
 fn test_jw_fermion_operator_to_spin() {
     let mut fo = FermionOperator::new();
+    let so = SpinOperator::new();
+
+    assert_eq!(fo.jordan_wigner(), so);
+
     let fp1 = FermionProduct::new([1, 2], [2, 3]).unwrap();
     let fp2 = FermionProduct::new([3, 4], [2, 5]).unwrap();
     fo.add_operator_product(fp1.clone(), CalculatorComplex::new(1.0, 2.0))
@@ -106,15 +117,16 @@ fn test_jw_fermion_hamiltonian_to_spin() {
 #[test]
 fn test_jw_fermion_noise_operator_to_spin() {
     let mut fno = FermionLindbladNoiseOperator::new();
+    let mut sno = SpinLindbladNoiseOperator::new();
+
+    assert_eq!(fno.jordan_wigner(), sno);
+
     let fp = FermionProduct::new([0], [0]).unwrap();
     fno.add_operator_product((fp.clone(), fp.clone()), CalculatorComplex::new(1.0, 0.0))
         .unwrap();
-    let mut sno = SpinLindbladNoiseOperator::new();
     let dp = DecoherenceProduct::new().z(0);
     sno.add_operator_product((dp.clone(), dp.clone()), CalculatorComplex::new(0.25, 0.0))
         .unwrap();
-
-    assert_eq!(fno.jordan_wigner(), sno)
 }
 
 #[test]

--- a/struqture/tests/mappings/jordan_wigner.rs
+++ b/struqture/tests/mappings/jordan_wigner.rs
@@ -14,13 +14,14 @@ use qoqo_calculator::{CalculatorComplex, CalculatorFloat};
 use struqture::fermions::{
     FermionHamiltonian, FermionHamiltonianSystem, FermionLindbladNoiseOperator,
     FermionLindbladNoiseSystem, FermionLindbladOpenSystem, FermionOperator, FermionProduct,
-    HermitianFermionProduct,
+    FermionSystem, HermitianFermionProduct,
 };
 use struqture::mappings::JordanWignerFermionToSpin;
 use struqture::prelude::*;
 use struqture::spins::{
     DecoherenceProduct, PauliProduct, SingleSpinOperator, SpinHamiltonian, SpinHamiltonianSystem,
     SpinLindbladNoiseOperator, SpinLindbladNoiseSystem, SpinLindbladOpenSystem, SpinOperator,
+    SpinSystem,
 };
 
 #[test]
@@ -131,6 +132,19 @@ fn test_jw_fermion_noise_operator_to_spin() {
 
 #[test]
 fn test_jw_fermion_systems_to_spin() {
+    // Test FermionSystem
+    let mut fo = FermionOperator::new();
+    fo.add_operator_product(
+        FermionProduct::new([1], [2]).unwrap(),
+        CalculatorComplex::new(1.0, 2.0),
+    )
+    .unwrap();
+    let fs = FermionSystem::from_operator(fo.clone(), Some(5)).unwrap();
+    let so = fo.jordan_wigner();
+    let ss = SpinSystem::from_operator(so, Some(5)).unwrap();
+
+    assert_eq!(fs.jordan_wigner(), ss);
+
     // Test FermionHamiltonianSystem
     let mut fh = FermionHamiltonian::new();
     fh.add_operator_product(

--- a/struqture/tests/mappings/jordan_wigner.rs
+++ b/struqture/tests/mappings/jordan_wigner.rs
@@ -12,14 +12,16 @@
 
 use qoqo_calculator::{CalculatorComplex, CalculatorFloat};
 use struqture::fermions::{
-    FermionHamiltonian, FermionLindbladNoiseOperator, FermionOperator, FermionProduct,
+    FermionHamiltonian, FermionHamiltonianSystem, FermionLindbladNoiseOperator,
+    FermionLindbladNoiseSystem, FermionLindbladOpenSystem, FermionOperator, FermionProduct,
     HermitianFermionProduct,
 };
 use struqture::mappings::JordanWignerFermionToSpin;
 use struqture::prelude::*;
 use struqture::spins::{
     DecoherenceProduct, PauliProduct, SingleDecoherenceOperator, SingleSpinOperator,
-    SpinHamiltonian, SpinLindbladNoiseOperator, SpinOperator,
+    SpinHamiltonian, SpinHamiltonianSystem, SpinLindbladNoiseOperator, SpinLindbladNoiseSystem,
+    SpinLindbladOpenSystem, SpinOperator,
 };
 
 #[test]
@@ -123,4 +125,38 @@ fn test_jw_fermion_noise_operator_to_spin() {
         .unwrap();
 
     assert_eq!(fno.jordan_wigner(), sno)
+}
+
+#[test]
+fn test_jw_fermion_systems_to_spin() {
+    // Test FermionHamiltonianSystem
+    let mut fh = FermionHamiltonian::new();
+    fh.add_operator_product(
+        HermitianFermionProduct::new([1], [2]).unwrap(),
+        CalculatorComplex::new(1.0, 2.0),
+    )
+    .unwrap();
+    let fhs = FermionHamiltonianSystem::from_hamiltonian(fh.clone(), Some(5)).unwrap();
+    let sh = fh.jordan_wigner();
+    let shs = SpinHamiltonianSystem::from_hamiltonian(sh, Some(5)).unwrap();
+
+    assert_eq!(fhs.jordan_wigner(), shs);
+
+    // Test FermionLindbladNoiseSystem
+    let mut fno = FermionLindbladNoiseOperator::new();
+    let fp1 = FermionProduct::new([1], [2]).unwrap();
+    let fp2 = FermionProduct::new([2], [3]).unwrap();
+    fno.add_operator_product((fp1, fp2), CalculatorComplex::new(1.0, 2.0))
+        .unwrap();
+    let fns = FermionLindbladNoiseSystem::from_operator(fno.clone(), Some(5)).unwrap();
+    let sno = fno.jordan_wigner();
+    let sns = SpinLindbladNoiseSystem::from_operator(sno, Some(5)).unwrap();
+
+    assert_eq!(fns.jordan_wigner(), sns);
+
+    // Test FermionLindbladOpenSystem
+    let sos = SpinLindbladOpenSystem::group(shs, sns).unwrap();
+    let fos = FermionLindbladOpenSystem::group(fhs, fns).unwrap();
+
+    assert_eq!(fos.jordan_wigner(), sos);
 }

--- a/struqture/tests/mappings/jordan_wigner.rs
+++ b/struqture/tests/mappings/jordan_wigner.rs
@@ -24,7 +24,7 @@ use struqture::spins::{PauliProduct,
 use struqture::mappings::JordanWignerFermionToSpin;
 
 #[test]
-fn test_jw_fermion_to_spin() {
+fn test_jw_fermion_product_to_spin() {
 
     let fp = FermionProduct::new([1], [2]).unwrap();
     let pp_1 = PauliProduct::new().y(1).x(2);
@@ -49,7 +49,7 @@ fn test_jw_fermion_to_spin() {
 }
 
 #[test]
-fn test_jw_fermion_to_spin_hermitian() {
+fn test_jw_hermitian_fermion_product_to_spin() {
 
     let hfp = HermitianFermionProduct::new([1], [2]).unwrap();  
     let pp_1 = PauliProduct::new().y(1).y(2);
@@ -60,4 +60,14 @@ fn test_jw_fermion_to_spin_hermitian() {
 
     assert_eq!(hfp.jordan_wigner(), so)
 
+}
+
+#[test]
+fn test_jw_fermion_operator_to_spin() {
+    // TODO
+}
+
+#[test]
+fn test_jw_fermion_hamiltonian_to_spin() {
+    // TODO 
 }

--- a/struqture/tests/mappings/jordan_wigner.rs
+++ b/struqture/tests/mappings/jordan_wigner.rs
@@ -10,37 +10,30 @@
 // express or implied. See the License for the specific language governing permissions and
 // limitations under the License.
 
-use qoqo_calculator::{
-    CalculatorComplex,
-    CalculatorFloat,
-};
-use struqture::prelude::*;
+use qoqo_calculator::{CalculatorComplex, CalculatorFloat};
 use struqture::fermions::{
-    FermionProduct,
-    HermitianFermionProduct,
-    FermionOperator,
-    FermionHamiltonian,
-};
-use struqture::spins::{PauliProduct,
-                       SpinHamiltonian,
-                       SpinOperator,
-                       SingleSpinOperator,
+    FermionHamiltonian, FermionOperator, FermionProduct, HermitianFermionProduct,
 };
 use struqture::mappings::JordanWignerFermionToSpin;
+use struqture::prelude::*;
+use struqture::spins::{PauliProduct, SingleSpinOperator, SpinHamiltonian, SpinOperator};
 
 #[test]
 fn test_jw_fermion_product_to_spin() {
-
     let fp = FermionProduct::new([1], [2]).unwrap();
     let pp_1 = PauliProduct::new().y(1).x(2);
     let pp_2 = PauliProduct::new().x(1).y(2);
     let pp_3 = PauliProduct::new().y(1).y(2);
     let pp_4 = PauliProduct::new().x(1).x(2);
     let mut so = SpinOperator::new();
-    so.add_operator_product(pp_1.clone(), CalculatorComplex::new(0.0, -0.25)).unwrap();
-    so.add_operator_product(pp_2.clone(), CalculatorComplex::new(0.0, 0.25)).unwrap();
-    so.add_operator_product(pp_3.clone(), CalculatorComplex::new(0.25, 0.0)).unwrap();
-    so.add_operator_product(pp_4.clone(), CalculatorComplex::new(0.25, 0.0)).unwrap();
+    so.add_operator_product(pp_1.clone(), CalculatorComplex::new(0.0, -0.25))
+        .unwrap();
+    so.add_operator_product(pp_2.clone(), CalculatorComplex::new(0.0, 0.25))
+        .unwrap();
+    so.add_operator_product(pp_3.clone(), CalculatorComplex::new(0.25, 0.0))
+        .unwrap();
+    so.add_operator_product(pp_4.clone(), CalculatorComplex::new(0.25, 0.0))
+        .unwrap();
 
     assert_eq!(fp.jordan_wigner(), so);
 
@@ -48,42 +41,43 @@ fn test_jw_fermion_product_to_spin() {
     let mut so = SpinOperator::new();
     let mut id = PauliProduct::new();
     id = id.set_pauli(0, SingleSpinOperator::Identity);
-    so.add_operator_product(id.clone(), CalculatorComplex::new(1.0, 0.0)).unwrap();
-    
+    so.add_operator_product(id.clone(), CalculatorComplex::new(1.0, 0.0))
+        .unwrap();
+
     assert_eq!(fp.jordan_wigner(), so)
 }
 
 #[test]
 fn test_jw_hermitian_fermion_product_to_spin() {
-
-    let hfp = HermitianFermionProduct::new([1], [2]).unwrap();  
+    let hfp = HermitianFermionProduct::new([1], [2]).unwrap();
     let pp_1 = PauliProduct::new().y(1).y(2);
     let pp_2 = PauliProduct::new().x(1).x(2);
     let mut so = SpinOperator::new();
-    so.add_operator_product(pp_1.clone(), CalculatorComplex::new(0.5, 0.0)).unwrap();
-    so.add_operator_product(pp_2.clone(), CalculatorComplex::new(0.5, 0.0)).unwrap();
+    so.add_operator_product(pp_1.clone(), CalculatorComplex::new(0.5, 0.0))
+        .unwrap();
+    so.add_operator_product(pp_2.clone(), CalculatorComplex::new(0.5, 0.0))
+        .unwrap();
 
     assert_eq!(hfp.jordan_wigner(), so)
-
 }
 
 #[test]
 fn test_jw_fermion_operator_to_spin() {
-
     let mut fo = FermionOperator::new();
     let fp1 = FermionProduct::new([1, 2], [2, 3]).unwrap();
     let fp2 = FermionProduct::new([3, 4], [2, 5]).unwrap();
-    fo.add_operator_product(fp1.clone(), CalculatorComplex::new(1.0, 2.0)).unwrap();
-    fo.add_operator_product(fp2.clone(), CalculatorComplex::new(2.0, 1.0)).unwrap();
-    let jw_pair1 = fp1.jordan_wigner()*CalculatorComplex::new(1.0, 2.0);
-    let jw_pair2 = fp2.jordan_wigner()*CalculatorComplex::new(2.0, 1.0);
+    fo.add_operator_product(fp1.clone(), CalculatorComplex::new(1.0, 2.0))
+        .unwrap();
+    fo.add_operator_product(fp2.clone(), CalculatorComplex::new(2.0, 1.0))
+        .unwrap();
+    let jw_pair1 = fp1.jordan_wigner() * CalculatorComplex::new(1.0, 2.0);
+    let jw_pair2 = fp2.jordan_wigner() * CalculatorComplex::new(2.0, 1.0);
 
     assert_eq!(fo.jordan_wigner(), jw_pair1 + jw_pair2);
 }
 
 #[test]
 fn test_jw_fermion_hamiltonian_to_spin() {
-
     let mut fh = FermionHamiltonian::new();
     let hfp1 = HermitianFermionProduct::new([1, 2], [2, 4]).unwrap();
     let hfp2 = HermitianFermionProduct::new([1, 3], [1, 2]).unwrap();
@@ -94,9 +88,9 @@ fn test_jw_fermion_hamiltonian_to_spin() {
     let jw_pair1_hamiltonian = SpinHamiltonian::try_from(jw_pair1).unwrap();
     let jw_pair2_hamiltonian = SpinHamiltonian::try_from(jw_pair2).unwrap();
 
-    assert_eq!(fh.jordan_wigner(),
-               jw_pair1_hamiltonian*CalculatorFloat::from(1.0) + 
-               jw_pair2_hamiltonian*CalculatorFloat::from(2.0)
+    assert_eq!(
+        fh.jordan_wigner(),
+        jw_pair1_hamiltonian * CalculatorFloat::from(1.0)
+            + jw_pair2_hamiltonian * CalculatorFloat::from(2.0)
     );
-
 }

--- a/struqture/tests/mappings/jordan_wigner.rs
+++ b/struqture/tests/mappings/jordan_wigner.rs
@@ -19,7 +19,7 @@ use struqture::fermions::{
 use struqture::mappings::JordanWignerFermionToSpin;
 use struqture::prelude::*;
 use struqture::spins::{
-    DecoherenceProduct, PauliProduct, SingleDecoherenceOperator, SingleSpinOperator,
+    DecoherenceProduct, PauliProduct, SingleSpinOperator,
     SpinHamiltonian, SpinHamiltonianSystem, SpinLindbladNoiseOperator, SpinLindbladNoiseSystem,
     SpinLindbladOpenSystem, SpinOperator,
 };
@@ -112,16 +112,6 @@ fn test_jw_fermion_noise_operator_to_spin() {
     let mut sno = SpinLindbladNoiseOperator::new();
     let dp = DecoherenceProduct::new().z(0);
     sno.add_operator_product((dp.clone(), dp.clone()), CalculatorComplex::new(0.25, 0.0))
-        .unwrap();
-
-    // TEMP adding extra terms that would cancel, because the implementation of
-    // SpinLindbladNoiseOperator still saves them
-    let id = DecoherenceProduct::new().set_pauli(0, SingleDecoherenceOperator::Identity);
-    sno.add_operator_product((id.clone(), id.clone()), CalculatorComplex::new(0.25, 0.0))
-        .unwrap();
-    sno.add_operator_product((id.clone(), dp.clone()), CalculatorComplex::new(-0.25, 0.0))
-        .unwrap();
-    sno.add_operator_product((dp.clone(), id.clone()), CalculatorComplex::new(-0.25, 0.0))
         .unwrap();
 
     assert_eq!(fno.jordan_wigner(), sno)

--- a/struqture/tests/mappings/jordan_wigner.rs
+++ b/struqture/tests/mappings/jordan_wigner.rs
@@ -1,0 +1,45 @@
+// Copyright © 2020-2022 HQS Quantum Simulations GmbH. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the
+// License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+use test_case::test_case;
+use qoqo_calculator::Calculatorcomplex;
+
+use crate::prelude::*;
+use crate::fermions::FermionProduct;
+use crate::spins::{PauliProduct, SpinOperator};
+use crate::mappings::jordan_wigner;
+
+
+// NOTE for the moment we work on tests only for the FermionProduct
+// implementation of the JordanWignerSpinToFermion trait.
+
+// TODO move to FermionProduct tests
+#[test]
+fn test_jw_fermion_to_spin() {
+
+    let creators = &[1];
+    let annihilators = &[2];
+    let fp = FermionProduct::new(creators.to_vec(), annihilators.to_vec()).unwrap();
+    let pp_1 = PauliProduct::new().y(1).x(2);
+    let pp_2 = PauliProduct::new().x(1).y(2);
+    let pp_3 = PauliProduct::new().y(1).y(2);
+    let pp_4 = PauliProduct::new().x(1).x(2);
+    let mut so = SpinOperator::new();
+    so.add_operator_product(pp_1.clone(), CalculatorComplex::new(0.0, -0.25)).unwrap();
+    so.add_operator_product(pp_2.clone(), CalculatorComplex::new(0.0, 0.25)).unwrap();
+    so.add_operator_product(pp_3.clone(), CalculatorComplex::new(0.25, 0.0)).unwrap();
+    so.add_operator_product(pp_4.clone(), CalculatorComplex::new(0.25, 0.0)).unwrap();
+
+    assert_eq!(fp.jordan_wigner(), sp)
+
+}
+

--- a/struqture/tests/mappings/jordan_wigner.rs
+++ b/struqture/tests/mappings/jordan_wigner.rs
@@ -18,8 +18,8 @@ use struqture::fermions::{
 use struqture::mappings::JordanWignerFermionToSpin;
 use struqture::prelude::*;
 use struqture::spins::{
-    DecoherenceProduct, PauliProduct, SingleSpinOperator, SpinHamiltonian,
-    SpinLindbladNoiseOperator, SpinOperator,
+    DecoherenceProduct, PauliProduct, SingleDecoherenceOperator, SingleSpinOperator,
+    SpinHamiltonian, SpinLindbladNoiseOperator, SpinOperator,
 };
 
 #[test]
@@ -109,7 +109,17 @@ fn test_jw_fermion_noise_operator_to_spin() {
         .unwrap();
     let mut sno = SpinLindbladNoiseOperator::new();
     let dp = DecoherenceProduct::new().z(0);
-    sno.add_operator_product((dp.clone(), dp), CalculatorComplex::new(0.25, 0.0))
+    sno.add_operator_product((dp.clone(), dp.clone()), CalculatorComplex::new(0.25, 0.0))
+        .unwrap();
+
+    // TEMP adding extra terms that would cancel, because the implementation of
+    // SpinLindbladNoiseOperator still saves them
+    let id = DecoherenceProduct::new().set_pauli(0, SingleDecoherenceOperator::Identity);
+    sno.add_operator_product((id.clone(), id.clone()), CalculatorComplex::new(0.25, 0.0))
+        .unwrap();
+    sno.add_operator_product((id.clone(), dp.clone()), CalculatorComplex::new(-0.25, 0.0))
+        .unwrap();
+    sno.add_operator_product((dp.clone(), id.clone()), CalculatorComplex::new(-0.25, 0.0))
         .unwrap();
 
     assert_eq!(fno.jordan_wigner(), sno)

--- a/struqture/tests/mappings/jordan_wigner.rs
+++ b/struqture/tests/mappings/jordan_wigner.rs
@@ -13,7 +13,10 @@
 use qoqo_calculator::CalculatorComplex;
 
 use struqture::prelude::*;
-use struqture::fermions::FermionProduct;
+use struqture::fermions::{
+    FermionProduct,
+    HermitianFermionProduct,
+};
 use struqture::spins::{PauliProduct,
                        SpinOperator,
                        SingleSpinOperator,
@@ -23,9 +26,7 @@ use struqture::mappings::JordanWignerFermionToSpin;
 #[test]
 fn test_jw_fermion_to_spin() {
 
-    let creators = &[1];
-    let annihilators = &[2];
-    let fp = FermionProduct::new(creators.to_vec(), annihilators.to_vec()).unwrap();
+    let fp = FermionProduct::new([1], [2]).unwrap();
     let pp_1 = PauliProduct::new().y(1).x(2);
     let pp_2 = PauliProduct::new().x(1).y(2);
     let pp_3 = PauliProduct::new().y(1).y(2);
@@ -47,3 +48,16 @@ fn test_jw_fermion_to_spin() {
     assert_eq!(fp.jordan_wigner(), so)
 }
 
+#[test]
+fn test_jw_fermion_to_spin_hermitian() {
+
+    let hfp = HermitianFermionProduct::new([1], [2]).unwrap();  
+    let pp_1 = PauliProduct::new().y(1).y(2);
+    let pp_2 = PauliProduct::new().x(1).x(2);
+    let mut so = SpinOperator::new();
+    so.add_operator_product(pp_1.clone(), CalculatorComplex::new(0.5, 0.0)).unwrap();
+    so.add_operator_product(pp_2.clone(), CalculatorComplex::new(0.5, 0.0)).unwrap();
+
+    assert_eq!(hfp.jordan_wigner(), so)
+
+}

--- a/struqture/tests/mappings/jordan_wigner.rs
+++ b/struqture/tests/mappings/jordan_wigner.rs
@@ -10,19 +10,16 @@
 // express or implied. See the License for the specific language governing permissions and
 // limitations under the License.
 
-use test_case::test_case;
-use qoqo_calculator::Calculatorcomplex;
+use qoqo_calculator::CalculatorComplex;
 
-use crate::prelude::*;
-use crate::fermions::FermionProduct;
-use crate::spins::{PauliProduct, SpinOperator};
-use crate::mappings::jordan_wigner;
+use struqture::prelude::*;
+use struqture::fermions::FermionProduct;
+use struqture::spins::{PauliProduct,
+                       SpinOperator,
+                       SingleSpinOperator,
+};
+use struqture::mappings::JordanWignerFermionToSpin;
 
-
-// NOTE for the moment we work on tests only for the FermionProduct
-// implementation of the JordanWignerSpinToFermion trait.
-
-// TODO move to FermionProduct tests
 #[test]
 fn test_jw_fermion_to_spin() {
 
@@ -39,7 +36,14 @@ fn test_jw_fermion_to_spin() {
     so.add_operator_product(pp_3.clone(), CalculatorComplex::new(0.25, 0.0)).unwrap();
     so.add_operator_product(pp_4.clone(), CalculatorComplex::new(0.25, 0.0)).unwrap();
 
-    assert_eq!(fp.jordan_wigner(), sp)
+    assert_eq!(fp.jordan_wigner(), so);
 
+    let fp = FermionProduct::new([], []).unwrap();
+    let mut so = SpinOperator::new();
+    let mut id = PauliProduct::new();
+    id = id.set_pauli(0, SingleSpinOperator::Identity);
+    so.add_operator_product(id.clone(), CalculatorComplex::new(1.0, 0.0)).unwrap();
+    
+    assert_eq!(fp.jordan_wigner(), so)
 }
 

--- a/struqture/tests/mappings/mod.rs
+++ b/struqture/tests/mappings/mod.rs
@@ -1,0 +1,13 @@
+// Copyright © 2020-2022 HQS Quantum Simulations GmbH. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the
+// License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod jordan_wigner;

--- a/struqture/tests/spins/decoherence_operator.rs
+++ b/struqture/tests/spins/decoherence_operator.rs
@@ -20,7 +20,7 @@ use std::iter::{FromIterator, IntoIterator};
 use std::ops::{Add, Sub};
 use std::str::FromStr;
 use struqture::prelude::*;
-use struqture::spins::{DecoherenceOperator, DecoherenceProduct};
+use struqture::spins::{DecoherenceOperator, DecoherenceProduct, PauliProduct, SpinOperator};
 use struqture::SpinIndex;
 use test_case::test_case;
 
@@ -208,6 +208,34 @@ fn into_iter_from_iter_extend() {
         .unwrap();
 
     assert_eq!(system, system_1);
+}
+
+// Test the From<SpinOperator> trait
+#[test]
+fn test_from_spin_operator() {
+    let mut so = SpinOperator::new();
+    let pp_0 = PauliProduct::new().x(0).y(1).z(2);
+    let c0 = CalculatorComplex::new(1.0, 2.0);
+    let pp_1 = PauliProduct::new().x(0).y(1).y(2);
+    let c1 = CalculatorComplex::new(2.0, 1.0);
+    let pp_2 = PauliProduct::new().y(0).y(1).y(2);
+    let c2 = CalculatorComplex::new(2.0, 3.0);
+    so.add_operator_product(pp_0, c0).unwrap();
+    so.add_operator_product(pp_1, c1).unwrap();
+    so.add_operator_product(pp_2, c2).unwrap();
+
+    let mut dec_op = DecoherenceOperator::new();
+    let dp_0 = DecoherenceProduct::new().x(0).iy(1).z(2);
+    let dp_1 = DecoherenceProduct::new().x(0).iy(1).iy(2);
+    let dp_2 = DecoherenceProduct::new().iy(0).iy(1).iy(2);
+    let d0 = CalculatorComplex::new(2.0, -1.0);
+    let d1 = CalculatorComplex::new(-2.0, -1.0);
+    let d2 = CalculatorComplex::new(-3.0, 2.0);
+    dec_op.add_operator_product(dp_0, d0).unwrap();
+    dec_op.add_operator_product(dp_1, d1).unwrap();
+    dec_op.add_operator_product(dp_2, d2).unwrap();
+
+    assert_eq!(DecoherenceOperator::from(so), dec_op);
 }
 
 // Test the negative operation: -DecoherenceOperator

--- a/struqture/tests/spins/decoherence_operator.rs
+++ b/struqture/tests/spins/decoherence_operator.rs
@@ -20,7 +20,7 @@ use std::iter::{FromIterator, IntoIterator};
 use std::ops::{Add, Sub};
 use std::str::FromStr;
 use struqture::prelude::*;
-use struqture::spins::{DecoherenceOperator, DecoherenceProduct};
+use struqture::spins::{DecoherenceOperator, DecoherenceProduct, PauliProduct, SpinOperator};
 use struqture::SpinIndex;
 use test_case::test_case;
 
@@ -475,6 +475,34 @@ fn mul_so_cf() {
     let _ = so_0_1.add_operator_product(pp_0, CalculatorComplex::from(6.0));
 
     assert_eq!(so_0 * CalculatorFloat::from(3.0), so_0_1);
+}
+
+// Test the From<SpinOperator> trait
+#[test]
+fn test_from_spin_operator() {
+    let mut so = SpinOperator::new();
+    let pp_0 = PauliProduct::new().x(0).y(1).z(2);
+    let c0 = CalculatorComplex::new(1.0, 2.0);
+    let pp_1 = PauliProduct::new().x(0).y(1).y(2);
+    let c1 = CalculatorComplex::new(2.0, 1.0);
+    let pp_2 = PauliProduct::new().y(0).y(1).y(2);
+    let c2 = CalculatorComplex::new(2.0, 3.0);
+    so.add_operator_product(pp_0, c0).unwrap();
+    so.add_operator_product(pp_1, c1).unwrap();
+    so.add_operator_product(pp_2, c2).unwrap();
+
+    let mut dec_op = DecoherenceOperator::new();
+    let dp_0 = DecoherenceProduct::new().x(0).iy(1).z(2);
+    let dp_1 = DecoherenceProduct::new().x(0).iy(1).iy(2);
+    let dp_2 = DecoherenceProduct::new().iy(0).iy(1).iy(2);
+    let d0 = CalculatorComplex::new(2.0, -1.0);
+    let d1 = CalculatorComplex::new(-2.0, -1.0);
+    let d2 = CalculatorComplex::new(-3.0, 2.0);
+    dec_op.add_operator_product(dp_0, d0).unwrap();
+    dec_op.add_operator_product(dp_1, d1).unwrap();
+    dec_op.add_operator_product(dp_2, d2).unwrap();
+
+    assert_eq!(DecoherenceOperator::from(so), dec_op);
 }
 
 // Test the Debug trait of DecoherenceOperator

--- a/struqture/tests/spins/decoherence_operator.rs
+++ b/struqture/tests/spins/decoherence_operator.rs
@@ -20,7 +20,7 @@ use std::iter::{FromIterator, IntoIterator};
 use std::ops::{Add, Sub};
 use std::str::FromStr;
 use struqture::prelude::*;
-use struqture::spins::{DecoherenceOperator, DecoherenceProduct, PauliProduct, SpinOperator};
+use struqture::spins::{DecoherenceOperator, DecoherenceProduct};
 use struqture::SpinIndex;
 use test_case::test_case;
 

--- a/struqture/tests/spins/plus_minus_noise_operator.rs
+++ b/struqture/tests/spins/plus_minus_noise_operator.rs
@@ -687,7 +687,6 @@ fn serde_compact() {
 fn so_from_pmo() {
     let pmp_vec: Vec<(PlusMinusProduct, CalculatorComplex)> = vec![
         (PlusMinusProduct::new().z(0), 3.0.into()),
-        (PlusMinusProduct::new(), 0.5.into()),
         (
             PlusMinusProduct::new().plus(1),
             CalculatorComplex::new(0.0, 1.0),
@@ -700,7 +699,6 @@ fn so_from_pmo() {
     ];
     let dp_vec: Vec<(DecoherenceProduct, CalculatorComplex)> = vec![
         (DecoherenceProduct::new().z(0), 3.0.into()),
-        (DecoherenceProduct::new(), 0.5.into()),
         (
             DecoherenceProduct::new().x(1),
             CalculatorComplex::new(0.0, 0.5),
@@ -760,7 +758,6 @@ fn so_from_pmo() {
 fn pmo_from_so() {
     let dp_vec: Vec<(DecoherenceProduct, CalculatorComplex)> = vec![
         (DecoherenceProduct::new().z(0), 1.0.into()),
-        (DecoherenceProduct::new(), 0.5.into()),
         (
             DecoherenceProduct::new().x(0),
             CalculatorComplex::new(0.0, 1.0),
@@ -776,7 +773,6 @@ fn pmo_from_so() {
             PlusMinusProduct::new().z(0),
             CalculatorComplex::new(1.0, 0.0),
         ),
-        (PlusMinusProduct::new(), CalculatorComplex::new(0.5, 0.0)),
         (
             PlusMinusProduct::new().plus(0),
             CalculatorComplex::new(0.0, 1.0),

--- a/struqture/tests/spins/spin_noise_operator.rs
+++ b/struqture/tests/spins/spin_noise_operator.rs
@@ -895,3 +895,26 @@ fn test_superoperator_multiple_entries() {
         assert_eq!(&val, second_val);
     }
 }
+
+// Test the failure of creating the SpinLindbladNoiseOperator with identity terms
+#[test]
+fn illegal_identity_operators() {
+    let empty_fp = DecoherenceProduct::new();
+    let fp = DecoherenceProduct::new().x(0);
+    let mut fno_left_identity = SpinLindbladNoiseOperator::new();
+    let cc = CalculatorComplex::new(1.0, 1.0);
+    let ok = fno_left_identity
+        .add_operator_product((empty_fp.clone(), fp.clone()), cc.clone())
+        .is_err();
+    assert!(ok);
+    let mut fno_right_identity = SpinLindbladNoiseOperator::new();
+    let ok = fno_right_identity
+        .add_operator_product((fp.clone(), empty_fp.clone()), cc.clone())
+        .is_err();
+    assert!(ok);
+    let mut fno_both_identity = SpinLindbladNoiseOperator::new();
+    let ok = fno_both_identity
+        .add_operator_product((empty_fp.clone(), empty_fp.clone()), cc)
+        .is_err();
+    assert!(ok);
+}


### PR DESCRIPTION
A trait JordanWignerFermionToSpin is implemented for the various fermionic data structures. Since every fermionic operator, Hamiltonian etc is built out of FermionProducts, every implementation of the trait extends the one for FermionProduct. 